### PR TITLE
Rm sushi . from ci-publisher

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Install modules
         run: npm install -g fsh-sushi
-      - name: Run sushi
-        run: sushi .
               
 
       # Downloads the newest version of the IG Publisher, this could probable be cached.


### PR DESCRIPTION
sushi . is automatically launched by ig publisher, there is no need to launch it before publisher