### PR TITLE
fix: utiliser graphviz apt ubuntu-24.04 au lieu de compiler depuis les sources

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,10 +151,11 @@ runs:
         run: |
           sudo gem install jekyll
           # GraphViz 2.42 (apt Ubuntu 22.04) incompatible avec PlantUML — installation version récente
+          # GraphViz 12.x incompatible avec PlantUML 1.2023.x (EmptySvgException) — utiliser 9.0.0
           sudo apt-get install -y cmake libgd-dev libpng-dev libfontconfig-dev
-          wget -q https://gitlab.com/graphviz/graphviz/-/archive/12.2.1/graphviz-12.2.1.tar.gz
-          tar -xzf graphviz-12.2.1.tar.gz
-          cd graphviz-12.2.1
+          wget -q https://gitlab.com/graphviz/graphviz/-/archive/9.0.0/graphviz-9.0.0.tar.gz
+          tar -xzf graphviz-9.0.0.tar.gz
+          cd graphviz-9.0.0
           cmake -B build -DCMAKE_BUILD_TYPE=Release
           cmake --build build -j$(nproc)
           sudo cmake --install build

--- a/action.yml
+++ b/action.yml
@@ -151,11 +151,11 @@ runs:
         run: |
           sudo gem install jekyll
           # GraphViz 2.42 (apt Ubuntu 22.04) incompatible avec PlantUML — installation version récente
-          # GraphViz 12.x incompatible avec PlantUML 1.2023.x (EmptySvgException) — utiliser 9.0.0
+          # GraphViz 12.x incompatible avec PlantUML 1.2023.x (EmptySvgException) — utiliser 14.1.5
           sudo apt-get install -y cmake libgd-dev libpng-dev libfontconfig-dev
-          wget -q https://gitlab.com/graphviz/graphviz/-/archive/9.0.0/graphviz-9.0.0.tar.gz
-          tar -xzf graphviz-9.0.0.tar.gz
-          cd graphviz-9.0.0
+          wget -q https://gitlab.com/graphviz/graphviz/-/archive/14.1.5/graphviz-14.1.5.tar.gz
+          tar -xzf graphviz-14.1.5.tar.gz
+          cd graphviz-14.1.5
           cmake -B build -DCMAKE_BUILD_TYPE=Release
           cmake --build build -j$(nproc)
           sudo cmake --install build

--- a/action.yml
+++ b/action.yml
@@ -147,26 +147,17 @@ runs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           
       - name: Install  jekyll and graphviz
-        shell: bash          
+        shell: bash
         run: |
           sudo gem install jekyll
-          # GraphViz 2.42 (apt Ubuntu 22.04) incompatible avec PlantUML — installation version récente
-          # GraphViz 12.x incompatible avec PlantUML 1.2023.x (EmptySvgException) — utiliser 14.1.5
-          sudo apt-get install -y cmake libgd-dev libpng-dev libfontconfig-dev
-          wget -q https://gitlab.com/graphviz/graphviz/-/archive/14.1.5/graphviz-14.1.5.tar.gz
-          tar -xzf graphviz-14.1.5.tar.gz
-          cd graphviz-14.1.5
-          cmake -B build -DCMAKE_BUILD_TYPE=Release
-          cmake --build build -j$(nproc)
-          sudo cmake --install build
+          # PlantUML 1.2026.x (publisher 2.2.9+) est compatible avec GraphViz apt
+          sudo apt-get install -y graphviz
           dot -V
 
-        
+
       # Creation de l'IG
       - name: 🏃‍♂️ Run IG Publisher
-        shell: bash 
-        env:
-          GRAPHVIZ_DOT: /usr/local/bin/dot
+        shell: bash
         run : |
               cd  ${{ inputs.repo_ig}}
               java -Xmx8192m -jar ../publisher.jar  -ig .   -authorise-non-conformant-tx-servers


### PR DESCRIPTION
## Description des changements

* Remplace la compilation de GraphViz 14.1.5 depuis les sources par `sudo apt-get install -y graphviz`
* Supprime la variable d'environnement `GRAPHVIZ_DOT=/usr/local/bin/dot` (plus nécessaire)
* PlantUML 1.2026.x (bundlé dans IG Publisher 2.2.9+) est compatible avec GraphViz 2.43.0 (apt ubuntu-24.04)

## Cause racine identifiée

Le problème n'était **pas** une incompatibilité de version entre PlantUML et GraphViz. GraphViz 14.1.5 compilé depuis les sources **crashait** sur ubuntu-24.04 (Broken Pipe / EmptySvgException), probablement en raison d'un plugin SVG manquant ou de bibliothèques dynamiques non configurées.

GraphViz 2.43.0 installé via apt fonctionne correctement avec PlantUML 1.2026.1.

**Validé** sur [nriss/test-plantuml-bug](https://nriss.github.io/test-plantuml-bug/main/ig/fr/) — les 8 diagrammes TDDUI se rendent sans erreur.

## Type de changement

- [x] Correction (erreur dans un profil, une page, une dépendance)

## Checklist

- [x] `sushi-config.yaml` : N/A (IG-workflows)
- [x] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`