### PR TITLE
feat: Docker image mode + cache JARs pour réduire les GitHub Minutes

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,69 @@
+name: Build and Push FHIR IG Builder image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .github/workflows/build-docker.yml
+  schedule:
+    # Rebuild hebdomadaire lundi 06:00 UTC pour capter les nouvelles versions SUSHI
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      sushi_version:
+        description: 'Version SUSHI à installer (défaut : dernière stable)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve SUSHI version
+        id: sushi-version
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.inputs.sushi_version }}" ]; then
+            VERSION="${{ github.event.inputs.sushi_version }}"
+          else
+            VERSION=$(npm view fsh-sushi version)
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "SUSHI version: $VERSION"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          build-args: SUSHI_VERSION=${{ steps.sushi-version.outputs.version }}
+          tags: |
+            ghcr.io/ansforge/fhir-ig-builder:latest
+            ghcr.io/ansforge/fhir-ig-builder:sushi-${{ steps.sushi-version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify image
+        run: |
+          docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest sushi --version
+          docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest java -version
+          docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest jekyll --version
+          docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest dot -V
+          docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest python3 --version

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,14 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Resolve SUSHI version
-        id: sushi-version
-        shell: bash
-        run: |
-          VERSION=$(npm view fsh-sushi version)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "SUSHI version: $VERSION"
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -45,10 +37,8 @@ jobs:
         with:
           context: .
           push: true
-          build-args: SUSHI_VERSION=${{ steps.sushi-version.outputs.version }}
           tags: |
             ghcr.io/ansforge/fhir-ig-builder:latest
-            ghcr.io/ansforge/fhir-ig-builder:sushi-${{ steps.sushi-version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,6 +7,7 @@ on:
       - Dockerfile
       - fhir-packages.txt
       - .github/workflows/build-docker.yml
+  workflow_dispatch:
   schedule:
     # Rebuild hebdomadaire lundi 06:00 UTC pour capter les nouvelles versions SUSHI
     - cron: '0 6 * * 1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,10 @@ COPY scripts/install-fhir-packages.mjs .
 COPY fhir-packages.txt .
 RUN node install-fhir-packages.mjs fhir-packages.txt
 
+# Pré-télécharger le IG Publisher JAR (version latest au moment du build de l'image)
+RUN PUBLISHER_VERSION=$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | jq -r '.tag_name') \
+    && wget -q "https://github.com/HL7/fhir-ig-publisher/releases/download/${PUBLISHER_VERSION}/publisher.jar" \
+        -O /root/publisher.jar \
+    && echo "IG Publisher ${PUBLISHER_VERSION} pre-installed at /root/publisher.jar"
+
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM ubuntu:24.04
+
+ARG SUSHI_VERSION=3.20.0
+ARG NODE_MAJOR=20
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+# System packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    wget \
+    git \
+    jq \
+    unzip \
+    graphviz \
+    python3 \
+    python3-pip \
+    ruby \
+    ruby-dev \
+    ruby-bundler \
+    build-essential \
+    openjdk-17-jdk-headless \
+    locales \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js 20 via NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# SUSHI (version épinglée via ARG — passer --build-arg SUSHI_VERSION=x.y.z pour mettre à jour)
+RUN npm install -g fsh-sushi@${SUSHI_VERSION}
+
+# Jekyll
+RUN gem install jekyll --no-document
+
+# GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | tee /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN java -version && node --version && sushi --version && jekyll --version && dot -V && python3 --version
+
+WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,26 +48,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 RUN java -version && node --version && sushi --version && jekyll --version && dot -V && python3 --version
 
-# Pré-chargement du cache FHIR depuis fhir-packages.txt
-# Chaque package est stocké sous /root/.fhir/packages/<id>#<version>/
-COPY fhir-packages.txt /tmp/fhir-packages.txt
-RUN while IFS=' ' read -r pkg_id pkg_ver || [ -n "$pkg_id" ]; do \
-      case "$pkg_id" in ''|\#*) continue ;; esac; \
-      if [ "$pkg_ver" = "latest" ]; then \
-        pkg_ver=$(curl -s "https://packages2.fhir.org/packages/${pkg_id}" | \
-          python3 -c " \
-import sys, json, re; \
-d = json.load(sys.stdin); \
-versions = list(d.get('versions', {}).keys()); \
-stable = [v for v in versions if re.match(r'^\d+\.\d+\.\d+$', v)]; \
-print(stable[-1] if stable else versions[-1]) \
-"); \
-      fi; \
-      echo "Downloading ${pkg_id}#${pkg_ver} ..."; \
-      mkdir -p /root/.fhir/packages/${pkg_id}\#${pkg_ver}; \
-      curl -sL "https://packages2.fhir.org/packages/${pkg_id}/${pkg_ver}" \
-        | tar -xz -C /root/.fhir/packages/${pkg_id}\#${pkg_ver}; \
-      echo "  -> OK"; \
-    done < /tmp/fhir-packages.txt
+# Pré-chargement du cache FHIR via fhir-package-installer
+# Installe les packages listés dans fhir-packages.txt dans /root/.fhir/packages/
+WORKDIR /opt/fhir-setup
+RUN npm init -y && npm install fhir-package-installer
+COPY scripts/install-fhir-packages.mjs .
+COPY fhir-packages.txt .
+RUN node install-fhir-packages.mjs fhir-packages.txt
 
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:24.04
 
-ARG SUSHI_VERSION=3.20.0
 ARG NODE_MAJOR=20
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
@@ -31,8 +30,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# SUSHI (version épinglée via ARG — passer --build-arg SUSHI_VERSION=x.y.z pour mettre à jour)
-RUN npm install -g fsh-sushi@${SUSHI_VERSION}
+# SUSHI (dernière version stable)
+RUN npm install -g fsh-sushi
 
 # Jekyll
 RUN gem install jekyll --no-document

--- a/action.yml
+++ b/action.yml
@@ -185,28 +185,35 @@ runs:
           fi
 
       # Résolution de la version du publisher (pour une clé de cache stable)
+      # En container_mode, si publisher.jar est pré-inclus dans l'image, on l'utilise directement
       - name: Resolve IG Publisher version
         id: resolve-publisher-version
         shell: bash
         run: |
-          if [ "${{ inputs.ig-publisher-version }}" = "latest" ]; then
+          if [ "${{ inputs.container_mode }}" = "true" ] && [ -f /root/publisher.jar ]; then
+            echo "version=image-bundled" >> $GITHUB_OUTPUT
+            echo "use_bundled=true" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.ig-publisher-version }}" = "latest" ]; then
             VERSION=$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | jq -r '.tag_name')
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "use_bundled=false" >> $GITHUB_OUTPUT
           else
-            VERSION="${{ inputs.ig-publisher-version }}"
+            echo "version=${{ inputs.ig-publisher-version }}" >> $GITHUB_OUTPUT
+            echo "use_bundled=false" >> $GITHUB_OUTPUT
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      # Cache du publisher.jar par version
+      # Cache du publisher.jar par version (skippé si publisher bundlé dans l'image)
       - name: Cache IG Publisher JAR
         id: cache-publisher
+        if: steps.resolve-publisher-version.outputs.use_bundled != 'true'
         uses: actions/cache@v4
         with:
           path: publisher.jar
           key: ig-publisher-${{ steps.resolve-publisher-version.outputs.version }}
 
-      # Téléchargement du publisher uniquement en cas de cache miss
+      # Téléchargement du publisher uniquement en cas de cache miss (skippé si bundlé)
       - name: 📥 Download IG Publisher
-        if: steps.cache-publisher.outputs.cache-hit != 'true'
+        if: steps.resolve-publisher-version.outputs.use_bundled != 'true' && steps.cache-publisher.outputs.cache-hit != 'true'
         shell: bash
         run: |
           wget -q https://github.com/HL7/fhir-ig-publisher/releases/download/${{ steps.resolve-publisher-version.outputs.version }}/publisher.jar
@@ -254,13 +261,19 @@ runs:
       # Run IG Publisher — mode legacy et container_mode (tourne directement)
       # En container_mode, on force HOME=/root pour que le subprocess SUSHI spawné par le Publisher
       # utilise /root/.fhir/packages (bind-monté depuis le host) et non /github/home/.fhir/packages.
+      # Si publisher bundlé dans l'image (/root/publisher.jar), on l'utilise directement.
       - name: 🏃‍♂️ Run IG Publisher
         if: ${{ inputs.use_docker_image != 'true' || inputs.container_mode == 'true' }}
         shell: bash
         run: |
           if [ "${{ inputs.container_mode }}" = "true" ]; then export HOME=/root; fi
+          if [ "${{ steps.resolve-publisher-version.outputs.use_bundled }}" = "true" ]; then
+            PUBLISHER_JAR=/root/publisher.jar
+          else
+            PUBLISHER_JAR=../publisher.jar
+          fi
           cd ${{ inputs.repo_ig }}
-          java -Xmx8192m -jar ../publisher.jar -ig . -authorise-non-conformant-tx-servers
+          java -Xmx8192m -jar $PUBLISHER_JAR -ig . -authorise-non-conformant-tx-servers
           [ -f ./output/qa.min.html ] && cat ./output/qa.min.html >> $GITHUB_STEP_SUMMARY
           mkdir ../to_publish/ig
           cp -r ./output/. ../to_publish/ig
@@ -282,7 +295,7 @@ runs:
           mkdir ./igs
           cp ../${{ inputs.repo_ig }}/output/package.tgz ./igs
           bundle install
-          bundle exec bin/testscript_generator read mustSupport search interaction  ig_directory./igs output_path=./generated_testscripts
+          bundle exec bin/testscript_generator read mustSupport search interaction ig_directory=./igs output_path=./generated_testscripts
           mkdir ../to_publish/testscript
           cp -r ./generated_testscripts/. ../to_publish/testscript
 
@@ -292,6 +305,17 @@ runs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
+      # Cache des JARs PlantUML (mode legacy et container_mode uniquement)
+      - name: Cache PlantUML JARs
+        id: cache-plantuml
+        if: ${{ (inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true') && (inputs.use_docker_image != 'true' || inputs.container_mode == 'true') }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            plantuml.jar
+            plantuml-mapping.jar
+          key: plantuml-jars-v1.2026.6-mapping-v1.2024.0
 
       # PlantUML — mode Docker (wrapper, pas en container_mode)
       - name: Run script plantuml
@@ -321,8 +345,8 @@ runs:
         run: |
           mkdir ./plantuml
           python ${{ github.action_path }}/PlantUML/construct.py './${{ inputs.repo_ig }}/output/package.db' './plantuml/graph.puml'
-          wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar
-          java -jar plantuml-1.2026.6.jar -tsvg -tpng "./plantuml"
+          [ -f plantuml.jar ] || wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O plantuml.jar
+          java -jar plantuml.jar -tsvg -tpng "./plantuml"
           mkdir ./to_publish/plantuml
           cp -r ./plantuml/. ./to_publish/plantuml
 
@@ -356,8 +380,8 @@ runs:
           mkdir ./plantuml_mapping
           python ${{ github.action_path }}/PlantUML/construct_mapping_global.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
           python ${{ github.action_path }}/PlantUML/construct_mappings.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
-          wget -q https://github.com/plantuml/plantuml/releases/download/v1.2024.0/plantuml-1.2024.0.jar
-          java -jar plantuml-1.2024.0.jar -tsvg -tpng "./plantuml"
+          [ -f plantuml-mapping.jar ] || wget -q https://github.com/plantuml/plantuml/releases/download/v1.2024.0/plantuml-1.2024.0.jar -O plantuml-mapping.jar
+          java -jar plantuml-mapping.jar -tsvg -tpng "./plantuml_mapping"
           mkdir ./to_publish/plantuml_mapping
           cp -r ./plantuml_mapping/. ./to_publish/plantuml_mapping
 

--- a/action.yml
+++ b/action.yml
@@ -47,16 +47,8 @@ inputs:
     description: "Chemin de publication de l'IG."
     required: false
     default: ""
-  use_docker_image:
-    description: "Utilise l'image pré-construite ghcr.io/ansforge/fhir-ig-builder pour éviter l'installation des outils à chaque run. Mettre à 'false' pour revenir au comportement legacy."
-    required: false
-    default: "false"
-  docker_image:
-    description: "Image Docker à utiliser quand use_docker_image est 'true'. Permet d'épingler une version spécifique."
-    required: false
-    default: "ghcr.io/ansforge/fhir-ig-builder:latest"
   container_mode:
-    description: "Le job tourne dans un container Docker (container: image: ...). Skip les installations d'outils et les wrappers docker run — SUSHI et Publisher tournent directement dans le container."
+    description: "Le job tourne dans un container Docker (container: image: ...). Skip les installations d'outils — SUSHI et Publisher tournent directement dans le container."
     required: false
     default: "false"
 runs:
@@ -68,22 +60,16 @@ runs:
         shell: bash
         run: mkdir to_publish
 
-      # Pull de l'image pré-construite (mode Docker uniquement, pas en container_mode)
-      - name: Pull FHIR IG Builder image
-        if: ${{ inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
-        shell: bash
-        run: docker pull ${{ inputs.docker_image }}
-
-      # Install JAVA (mode legacy uniquement — Docker et container_mode ont déjà le JDK)
+      # Install JAVA (mode legacy uniquement — container_mode a déjà le JDK)
       - name: Setup Java JDK
-        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
+        if: ${{ inputs.container_mode != 'true' }}
         uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'
 
       - uses: actions/setup-node@v4
-        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
+        if: ${{ inputs.container_mode != 'true' }}
         with:
           node-version: 20
 
@@ -131,7 +117,7 @@ runs:
           cp hl7.fhir.fr.core-1.1.0.tgz ~/.fhir/packages
           tar -xzvf ~/.fhir/packages/hl7.fhir.fr.core-1.1.0.tgz
 
-      # Cache des packages FHIR — mode legacy et use_docker_image (home standard du runner)
+      # Cache des packages FHIR — mode legacy (home standard du runner)
       - name: Cache FHIR packages
         if: ${{ inputs.container_mode != 'true' }}
         uses: actions/cache@v4
@@ -152,30 +138,15 @@ runs:
           restore-keys: |
             fhir-packages-
 
-      # SUSHI — mode Docker (wrapper docker run, pas en container_mode)
-      - name: Run sushi
-        if: ${{ inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
-        shell: bash
-        run: |
-          mkdir -p "$HOME/.fhir/packages"
-          docker run --rm \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            -v "$HOME/.fhir/packages:/root/.fhir/packages" \
-            -w /workspace \
-            ${{ inputs.docker_image }} \
-            sushi ${{ inputs.repo_ig }}
-
-      # SUSHI — mode legacy et container_mode (SUSHI déjà installé en container_mode, npm skippé)
+      # SUSHI — mode legacy (SUSHI installé via npm)
       - name: Install modules
-        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
+        if: ${{ inputs.container_mode != 'true' }}
         shell: bash
         run: npm install -g fsh-sushi
 
       # En container_mode, GHA force HOME=/github/home dans le container.
-      # On surcharge inline pour que SUSHI trouve ses packages dans /root/.fhir/packages
-      # (cible du volume mount). HOME=/root n'affecte que ce process, pas GITHUB_ENV.
+      # On surcharge inline pour que SUSHI trouve ses packages dans /root/.fhir/packages.
       - name: Run sushi
-        if: ${{ inputs.use_docker_image != 'true' || inputs.container_mode == 'true' }}
         shell: bash
         run: |
           if [ "${{ inputs.container_mode }}" = "true" ]; then
@@ -224,46 +195,26 @@ runs:
         id: branch-name
         uses: tj-actions/branch-names@v8
 
-      # Ruby/Jekyll/GraphViz — mode legacy uniquement (Docker et container_mode ont déjà ces outils)
+      # Ruby/Jekyll/GraphViz — mode legacy uniquement (container_mode a déjà ces outils)
       - uses: ruby/setup-ruby@v1
-        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
+        if: ${{ inputs.container_mode != 'true' }}
         with:
           ruby-version: '3.3'
           bundler-cache: true
 
       - name: Install jekyll and graphviz
-        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
+        if: ${{ inputs.container_mode != 'true' }}
         shell: bash
         run: |
           sudo gem install jekyll
           sudo apt-get install -y graphviz
           dot -V
 
-      # Run IG Publisher — mode Docker (wrapper docker run, pas en container_mode)
-      - name: 🏃‍♂️ Run IG Publisher
-        if: ${{ inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
-        shell: bash
-        run: |
-          mkdir -p "$HOME/.fhir/packages"
-          docker run --rm \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            -v "$HOME/.fhir/packages:/root/.fhir/packages" \
-            -w /workspace/${{ inputs.repo_ig }} \
-            ${{ inputs.docker_image }} \
-            bash -c "
-              java -Xmx8192m -jar /workspace/publisher.jar -ig . -authorise-non-conformant-tx-servers
-              [ -f ./output/qa.min.html ] && cat ./output/qa.min.html > /workspace/_qa_summary.txt || true
-              mkdir -p /workspace/to_publish/ig
-              cp -r ./output/. /workspace/to_publish/ig
-            "
-          [ -f "$GITHUB_WORKSPACE/_qa_summary.txt" ] && cat "$GITHUB_WORKSPACE/_qa_summary.txt" >> "$GITHUB_STEP_SUMMARY" || true
-
-      # Run IG Publisher — mode legacy et container_mode (tourne directement)
+      # Run IG Publisher
       # En container_mode, on force HOME=/root pour que le subprocess SUSHI spawné par le Publisher
-      # utilise /root/.fhir/packages (bind-monté depuis le host) et non /github/home/.fhir/packages.
+      # utilise /root/.fhir/packages et non /github/home/.fhir/packages.
       # Si publisher bundlé dans l'image (/root/publisher.jar), on l'utilise directement.
       - name: 🏃‍♂️ Run IG Publisher
-        if: ${{ inputs.use_docker_image != 'true' || inputs.container_mode == 'true' }}
         shell: bash
         run: |
           if [ "${{ inputs.container_mode }}" = "true" ]; then export HOME=/root; fi
@@ -299,17 +250,17 @@ runs:
           mkdir ../to_publish/testscript
           cp -r ./generated_testscripts/. ../to_publish/testscript
 
-      # Python — mode legacy uniquement (Docker et container_mode ont déjà Python)
+      # Python — mode legacy uniquement (container_mode a déjà Python)
       - name: Setup Python
-        if: ${{ (inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true') && inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
+        if: ${{ (inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true') && inputs.container_mode != 'true' }}
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
-      # Cache des JARs PlantUML (mode legacy et container_mode uniquement)
+      # Cache des JARs PlantUML
       - name: Cache PlantUML JARs
         id: cache-plantuml
-        if: ${{ (inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true') && (inputs.use_docker_image != 'true' || inputs.container_mode == 'true') }}
+        if: ${{ inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true' }}
         uses: actions/cache@v4
         with:
           path: |
@@ -317,29 +268,9 @@ runs:
             plantuml-mapping.jar
           key: plantuml-jars-v1.2026.6-mapping-v1.2024.0
 
-      # PlantUML — mode Docker (wrapper, pas en container_mode)
+      # PlantUML
       - name: Run script plantuml
-        if: ${{ inputs.generate_plantuml == 'true' && inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
-        shell: bash
-        continue-on-error: true
-        run: |
-          mkdir ./plantuml
-          docker run --rm \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            -v "${{ github.action_path }}:/opt/ig-workflows" \
-            -w /workspace \
-            ${{ inputs.docker_image }} \
-            bash -c "
-              python3 /opt/ig-workflows/PlantUML/construct.py './${{ inputs.repo_ig }}/output/package.db' './plantuml/graph.puml'
-              wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O /tmp/plantuml.jar
-              java -jar /tmp/plantuml.jar -tsvg -tpng ./plantuml
-            "
-          mkdir ./to_publish/plantuml
-          cp -r ./plantuml/. ./to_publish/plantuml
-
-      # PlantUML — mode legacy et container_mode
-      - name: Run script plantuml
-        if: ${{ inputs.generate_plantuml == 'true' && (inputs.use_docker_image != 'true' || inputs.container_mode == 'true') }}
+        if: ${{ inputs.generate_plantuml == 'true' }}
         shell: bash
         continue-on-error: true
         run: |
@@ -350,30 +281,9 @@ runs:
           mkdir ./to_publish/plantuml
           cp -r ./plantuml/. ./to_publish/plantuml
 
-      # PlantUML mapping — mode Docker (wrapper, pas en container_mode)
+      # PlantUML mapping
       - name: Run scripts mapping plantuml
-        if: ${{ inputs.generate_mapping_plantuml == 'true' && inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
-        shell: bash
-        continue-on-error: true
-        run: |
-          mkdir ./plantuml_mapping
-          docker run --rm \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            -v "${{ github.action_path }}:/opt/ig-workflows" \
-            -w /workspace \
-            ${{ inputs.docker_image }} \
-            bash -c "
-              python3 /opt/ig-workflows/PlantUML/construct_mapping_global.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
-              python3 /opt/ig-workflows/PlantUML/construct_mappings.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
-              wget -q https://github.com/plantuml/plantuml/releases/download/v1.2024.0/plantuml-1.2024.0.jar -O /tmp/plantuml-mapping.jar
-              java -jar /tmp/plantuml-mapping.jar -tsvg -tpng ./plantuml_mapping
-            "
-          mkdir ./to_publish/plantuml_mapping
-          cp -r ./plantuml_mapping/. ./to_publish/plantuml_mapping
-
-      # PlantUML mapping — mode legacy et container_mode
-      - name: Run scripts mapping plantuml
-        if: ${{ inputs.generate_mapping_plantuml == 'true' && (inputs.use_docker_image != 'true' || inputs.container_mode == 'true') }}
+        if: ${{ inputs.generate_mapping_plantuml == 'true' }}
         shell: bash
         continue-on-error: true
         run: |
@@ -410,22 +320,9 @@ runs:
         run: |
           wget -q https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar
 
-      # Run validator_cli — mode Docker (wrapper, pas en container_mode)
+      # Run validator_cli
       - name: ✔️ Run tests
-        if: ${{ inputs.validator_cli == 'true' && inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
-        shell: bash
-        continue-on-error: true
-        run: |
-          mkdir ./validator_cli
-          docker run --rm \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            -w /workspace/${{ inputs.repo_ig }} \
-            ${{ inputs.docker_image }} \
-            java -jar /workspace/validator_cli.jar ./fsh-generated/resources -recurse -verbose -output-style compact -output /workspace/validator_cli/rapport.html
-
-      # Run validator_cli — mode legacy et container_mode
-      - name: ✔️ Run tests
-        if: ${{ inputs.validator_cli == 'true' && (inputs.use_docker_image != 'true' || inputs.container_mode == 'true') }}
+        if: ${{ inputs.validator_cli == 'true' }}
         shell: bash
         continue-on-error: true
         run: |
@@ -460,14 +357,6 @@ runs:
           commit_message: ' ${{ github.event.head_commit.message }}'
 
 #####Release###########
-
-      # Java nécessaire sur le runner hôte pour le mode Docker + release (pas en container_mode où Java est déjà présent)
-      - name: Setup Java JDK (for release)
-        if: ${{ inputs.use_docker_image == 'true' && inputs.container_mode != 'true' && inputs.publish_repo != '' }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'microsoft'
-          java-version: '17'
 
       # Suppression cache ubuntu
       - name: Free Disk Space (Ubuntu)
@@ -505,7 +394,13 @@ runs:
       - name: 🏃‍♂️ Run Publisher to release
         if: ${{ inputs.publish_repo != '' }}
         shell: bash
-        run: java -jar publisher.jar -go-publish -authorise-non-conformant-tx-servers -source ${{ inputs.repo_ig }} -web ${{ inputs.publish_path_outpout }} -registry ./IG-website-release/ig-registry/fhir-ig-list.json -history ./IG-website-release/fhir-ig-history-template -templates ./IG-website-release/templates
+        run: |
+          if [ "${{ steps.resolve-publisher-version.outputs.use_bundled }}" = "true" ]; then
+            PUBLISHER_JAR=/root/publisher.jar
+          else
+            PUBLISHER_JAR=publisher.jar
+          fi
+          java -jar $PUBLISHER_JAR -go-publish -authorise-non-conformant-tx-servers -source ${{ inputs.repo_ig }} -web ${{ inputs.publish_path_outpout }} -registry ./IG-website-release/ig-registry/fhir-ig-list.json -history ./IG-website-release/fhir-ig-history-template -templates ./IG-website-release/templates
 
       # Commit de la release
       - name: Commit change

--- a/action.yml
+++ b/action.yml
@@ -131,18 +131,24 @@ runs:
           cp hl7.fhir.fr.core-1.1.0.tgz ~/.fhir/packages
           tar -xzvf ~/.fhir/packages/hl7.fhir.fr.core-1.1.0.tgz
 
-      # En container_mode, GHA peut setter HOME à autre chose que /root — on force /root pour
-      # que ~/.fhir/packages pointe vers les packages pré-chargés dans l'image
-      - name: Set HOME for container mode
-        if: ${{ inputs.container_mode == 'true' }}
-        shell: bash
-        run: echo "HOME=/root" >> $GITHUB_ENV
-
-      # Cache des packages FHIR — évite les re-téléchargements à chaque run (les deux modes)
+      # Cache des packages FHIR — mode legacy et use_docker_image (home standard du runner)
       - name: Cache FHIR packages
+        if: ${{ inputs.container_mode != 'true' }}
         uses: actions/cache@v4
         with:
           path: ~/.fhir/packages
+          key: fhir-packages-${{ hashFiles(format('{0}/sushi-config.yaml', inputs.repo_ig)) }}
+          restore-keys: |
+            fhir-packages-
+
+      # Cache des packages FHIR — container_mode : chemin absolu pour coller au volume mount
+      # actions/cache tourne sur le HOST (JavaScript action), donc ~ = /home/runner.
+      # Le volume mount connecte exactement /home/runner/.fhir/packages → /root/.fhir/packages.
+      - name: Cache FHIR packages (container mode)
+        if: ${{ inputs.container_mode == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.fhir/packages
           key: fhir-packages-${{ hashFiles(format('{0}/sushi-config.yaml', inputs.repo_ig)) }}
           restore-keys: |
             fhir-packages-
@@ -166,10 +172,18 @@ runs:
         shell: bash
         run: npm install -g fsh-sushi
 
+      # En container_mode, GHA force HOME=/github/home dans le container.
+      # On surcharge inline pour que SUSHI trouve ses packages dans /root/.fhir/packages
+      # (cible du volume mount). HOME=/root n'affecte que ce process, pas GITHUB_ENV.
       - name: Run sushi
         if: ${{ inputs.use_docker_image != 'true' || inputs.container_mode == 'true' }}
         shell: bash
-        run: sushi ${{ inputs.repo_ig }}
+        run: |
+          if [ "${{ inputs.container_mode }}" = "true" ]; then
+            HOME=/root sushi ${{ inputs.repo_ig }}
+          else
+            sushi ${{ inputs.repo_ig }}
+          fi
 
       # Résolution de la version du publisher (pour une clé de cache stable)
       - name: Resolve IG Publisher version

--- a/action.yml
+++ b/action.yml
@@ -127,13 +127,24 @@ runs:
           cp hl7.fhir.fr.core-1.1.0.tgz ~/.fhir/packages
           tar -xzvf ~/.fhir/packages/hl7.fhir.fr.core-1.1.0.tgz
 
+      # Cache des packages FHIR — évite les re-téléchargements à chaque run (les deux modes)
+      - name: Cache FHIR packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.fhir/packages
+          key: fhir-packages-${{ hashFiles(format('{0}/sushi-config.yaml', inputs.repo_ig)) }}
+          restore-keys: |
+            fhir-packages-
+
       # SUSHI — mode Docker
       - name: Run sushi
         if: ${{ inputs.use_docker_image == 'true' }}
         shell: bash
         run: |
+          mkdir -p "$HOME/.fhir/packages"
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
+            -v "$HOME/.fhir/packages:/root/.fhir/packages" \
             -w /workspace \
             ${{ inputs.docker_image }} \
             sushi ${{ inputs.repo_ig }}
@@ -202,8 +213,10 @@ runs:
         if: ${{ inputs.use_docker_image == 'true' }}
         shell: bash
         run: |
+          mkdir -p "$HOME/.fhir/packages"
           docker run --rm \
             -v "$GITHUB_WORKSPACE:/workspace" \
+            -v "$HOME/.fhir/packages:/root/.fhir/packages" \
             -w /workspace/${{ inputs.repo_ig }} \
             ${{ inputs.docker_image }} \
             bash -c "

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: "Image Docker à utiliser quand use_docker_image est 'true'. Permet d'épingler une version spécifique."
     required: false
     default: "ghcr.io/ansforge/fhir-ig-builder:latest"
+  container_mode:
+    description: "Le job tourne dans un container Docker (container: image: ...). Skip les installations d'outils et les wrappers docker run — SUSHI et Publisher tournent directement dans le container."
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -64,22 +68,22 @@ runs:
         shell: bash
         run: mkdir to_publish
 
-      # Pull de l'image pré-construite (mode Docker)
+      # Pull de l'image pré-construite (mode Docker uniquement, pas en container_mode)
       - name: Pull FHIR IG Builder image
-        if: ${{ inputs.use_docker_image == 'true' }}
+        if: ${{ inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
         shell: bash
         run: docker pull ${{ inputs.docker_image }}
 
-      # Install JAVA (mode legacy uniquement — le mode Docker utilise le JDK de l'image)
+      # Install JAVA (mode legacy uniquement — Docker et container_mode ont déjà le JDK)
       - name: Setup Java JDK
-        if: ${{ inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
         uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '17'
 
       - uses: actions/setup-node@v4
-        if: ${{ inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
         with:
           node-version: 20
 
@@ -136,9 +140,9 @@ runs:
           restore-keys: |
             fhir-packages-
 
-      # SUSHI — mode Docker
+      # SUSHI — mode Docker (wrapper docker run, pas en container_mode)
       - name: Run sushi
-        if: ${{ inputs.use_docker_image == 'true' }}
+        if: ${{ inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
         shell: bash
         run: |
           mkdir -p "$HOME/.fhir/packages"
@@ -149,14 +153,14 @@ runs:
             ${{ inputs.docker_image }} \
             sushi ${{ inputs.repo_ig }}
 
-      # SUSHI — mode legacy
+      # SUSHI — mode legacy et container_mode (SUSHI déjà installé en container_mode, npm skippé)
       - name: Install modules
-        if: ${{ inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
         shell: bash
         run: npm install -g fsh-sushi
 
       - name: Run sushi
-        if: ${{ inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.use_docker_image != 'true' || inputs.container_mode == 'true' }}
         shell: bash
         run: sushi ${{ inputs.repo_ig }}
 
@@ -193,24 +197,24 @@ runs:
         id: branch-name
         uses: tj-actions/branch-names@v8
 
-      # Ruby/Jekyll/GraphViz — mode legacy uniquement
+      # Ruby/Jekyll/GraphViz — mode legacy uniquement (Docker et container_mode ont déjà ces outils)
       - uses: ruby/setup-ruby@v1
-        if: ${{ inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
         with:
           ruby-version: '3.3'
           bundler-cache: true
 
       - name: Install jekyll and graphviz
-        if: ${{ inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
         shell: bash
         run: |
           sudo gem install jekyll
           sudo apt-get install -y graphviz
           dot -V
 
-      # Run IG Publisher — mode Docker
+      # Run IG Publisher — mode Docker (wrapper docker run, pas en container_mode)
       - name: 🏃‍♂️ Run IG Publisher
-        if: ${{ inputs.use_docker_image == 'true' }}
+        if: ${{ inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
         shell: bash
         run: |
           mkdir -p "$HOME/.fhir/packages"
@@ -227,9 +231,9 @@ runs:
             "
           [ -f "$GITHUB_WORKSPACE/_qa_summary.txt" ] && cat "$GITHUB_WORKSPACE/_qa_summary.txt" >> "$GITHUB_STEP_SUMMARY" || true
 
-      # Run IG Publisher — mode legacy
+      # Run IG Publisher — mode legacy et container_mode (tourne directement)
       - name: 🏃‍♂️ Run IG Publisher
-        if: ${{ inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.use_docker_image != 'true' || inputs.container_mode == 'true' }}
         shell: bash
         run: |
           cd ${{ inputs.repo_ig }}
@@ -259,16 +263,16 @@ runs:
           mkdir ../to_publish/testscript
           cp -r ./generated_testscripts/. ../to_publish/testscript
 
-      # Python — mode legacy uniquement (l'image Docker contient déjà Python)
+      # Python — mode legacy uniquement (Docker et container_mode ont déjà Python)
       - name: Setup Python
-        if: ${{ (inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true') && inputs.use_docker_image != 'true' }}
+        if: ${{ (inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true') && inputs.use_docker_image != 'true' && inputs.container_mode != 'true' }}
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
-      # PlantUML — mode Docker
+      # PlantUML — mode Docker (wrapper, pas en container_mode)
       - name: Run script plantuml
-        if: ${{ inputs.generate_plantuml == 'true' && inputs.use_docker_image == 'true' }}
+        if: ${{ inputs.generate_plantuml == 'true' && inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
         shell: bash
         continue-on-error: true
         run: |
@@ -286,9 +290,9 @@ runs:
           mkdir ./to_publish/plantuml
           cp -r ./plantuml/. ./to_publish/plantuml
 
-      # PlantUML — mode legacy
+      # PlantUML — mode legacy et container_mode
       - name: Run script plantuml
-        if: ${{ inputs.generate_plantuml == 'true' && inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.generate_plantuml == 'true' && (inputs.use_docker_image != 'true' || inputs.container_mode == 'true') }}
         shell: bash
         continue-on-error: true
         run: |
@@ -299,9 +303,9 @@ runs:
           mkdir ./to_publish/plantuml
           cp -r ./plantuml/. ./to_publish/plantuml
 
-      # PlantUML mapping — mode Docker
+      # PlantUML mapping — mode Docker (wrapper, pas en container_mode)
       - name: Run scripts mapping plantuml
-        if: ${{ inputs.generate_mapping_plantuml == 'true' && inputs.use_docker_image == 'true' }}
+        if: ${{ inputs.generate_mapping_plantuml == 'true' && inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
         shell: bash
         continue-on-error: true
         run: |
@@ -320,9 +324,9 @@ runs:
           mkdir ./to_publish/plantuml_mapping
           cp -r ./plantuml_mapping/. ./to_publish/plantuml_mapping
 
-      # PlantUML mapping — mode legacy
+      # PlantUML mapping — mode legacy et container_mode
       - name: Run scripts mapping plantuml
-        if: ${{ inputs.generate_mapping_plantuml == 'true' && inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.generate_mapping_plantuml == 'true' && (inputs.use_docker_image != 'true' || inputs.container_mode == 'true') }}
         shell: bash
         continue-on-error: true
         run: |
@@ -359,9 +363,9 @@ runs:
         run: |
           wget -q https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar
 
-      # Run validator_cli — mode Docker
+      # Run validator_cli — mode Docker (wrapper, pas en container_mode)
       - name: ✔️ Run tests
-        if: ${{ inputs.validator_cli == 'true' && inputs.use_docker_image == 'true' }}
+        if: ${{ inputs.validator_cli == 'true' && inputs.use_docker_image == 'true' && inputs.container_mode != 'true' }}
         shell: bash
         continue-on-error: true
         run: |
@@ -372,9 +376,9 @@ runs:
             ${{ inputs.docker_image }} \
             java -jar /workspace/validator_cli.jar ./fsh-generated/resources -recurse -verbose -output-style compact -output /workspace/validator_cli/rapport.html
 
-      # Run validator_cli — mode legacy
+      # Run validator_cli — mode legacy et container_mode
       - name: ✔️ Run tests
-        if: ${{ inputs.validator_cli == 'true' && inputs.use_docker_image != 'true' }}
+        if: ${{ inputs.validator_cli == 'true' && (inputs.use_docker_image != 'true' || inputs.container_mode == 'true') }}
         shell: bash
         continue-on-error: true
         run: |
@@ -410,9 +414,9 @@ runs:
 
 #####Release###########
 
-      # Java nécessaire sur le runner hôte pour le mode Docker + release
+      # Java nécessaire sur le runner hôte pour le mode Docker + release (pas en container_mode où Java est déjà présent)
       - name: Setup Java JDK (for release)
-        if: ${{ inputs.use_docker_image == 'true' && inputs.publish_repo != '' }}
+        if: ${{ inputs.use_docker_image == 'true' && inputs.container_mode != 'true' && inputs.publish_repo != '' }}
         uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ inputs:
   use_docker_image:
     description: "Utilise l'image pré-construite ghcr.io/ansforge/fhir-ig-builder pour éviter l'installation des outils à chaque run. Mettre à 'false' pour revenir au comportement legacy."
     required: false
-    default: "true"
+    default: "false"
   docker_image:
     description: "Image Docker à utiliser quand use_docker_image est 'true'. Permet d'épingler une version spécifique."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -253,10 +253,13 @@ runs:
           [ -f "$GITHUB_WORKSPACE/_qa_summary.txt" ] && cat "$GITHUB_WORKSPACE/_qa_summary.txt" >> "$GITHUB_STEP_SUMMARY" || true
 
       # Run IG Publisher — mode legacy et container_mode (tourne directement)
+      # En container_mode, on force HOME=/root pour que le subprocess SUSHI spawné par le Publisher
+      # utilise /root/.fhir/packages (bind-monté depuis le host) et non /github/home/.fhir/packages.
       - name: 🏃‍♂️ Run IG Publisher
         if: ${{ inputs.use_docker_image != 'true' || inputs.container_mode == 'true' }}
         shell: bash
         run: |
+          if [ "${{ inputs.container_mode }}" = "true" ]; then export HOME=/root; fi
           cd ${{ inputs.repo_ig }}
           java -Xmx8192m -jar ../publisher.jar -ig . -authorise-non-conformant-tx-servers
           [ -f ./output/qa.min.html ] && cat ./output/qa.min.html >> $GITHUB_STEP_SUMMARY

--- a/action.yml
+++ b/action.yml
@@ -131,6 +131,13 @@ runs:
           cp hl7.fhir.fr.core-1.1.0.tgz ~/.fhir/packages
           tar -xzvf ~/.fhir/packages/hl7.fhir.fr.core-1.1.0.tgz
 
+      # En container_mode, GHA peut setter HOME à autre chose que /root — on force /root pour
+      # que ~/.fhir/packages pointe vers les packages pré-chargés dans l'image
+      - name: Set HOME for container mode
+        if: ${{ inputs.container_mode == 'true' }}
+        shell: bash
+        run: echo "HOME=/root" >> $GITHUB_ENV
+
       # Cache des packages FHIR — évite les re-téléchargements à chaque run (les deux modes)
       - name: Cache FHIR packages
         uses: actions/cache@v4

--- a/action.yml
+++ b/action.yml
@@ -127,8 +127,9 @@ runs:
           restore-keys: |
             fhir-packages-
 
-      # Cache des packages FHIR — container_mode : actions/cache tourne DANS le container via
-      # docker exec, donc ~ = /github/home (HOME GHA). On cible /root/.fhir/packages en absolu.
+      # Cache des packages FHIR — container_mode : dans un job container, actions/cache s'exécute
+      # à l'intérieur du container (via docker exec). GHA y force HOME=/github/home, donc ~ ne
+      # pointe pas vers /root. On utilise le chemin absolu /root/.fhir/packages pour être sûr.
       - name: Cache FHIR packages (container mode)
         if: ${{ inputs.container_mode == 'true' }}
         uses: actions/cache@v4

--- a/action.yml
+++ b/action.yml
@@ -141,14 +141,13 @@ runs:
           restore-keys: |
             fhir-packages-
 
-      # Cache des packages FHIR — container_mode : chemin absolu pour coller au volume mount
-      # actions/cache tourne sur le HOST (JavaScript action), donc ~ = /home/runner.
-      # Le volume mount connecte exactement /home/runner/.fhir/packages → /root/.fhir/packages.
+      # Cache des packages FHIR — container_mode : actions/cache tourne DANS le container via
+      # docker exec, donc ~ = /github/home (HOME GHA). On cible /root/.fhir/packages en absolu.
       - name: Cache FHIR packages (container mode)
         if: ${{ inputs.container_mode == 'true' }}
         uses: actions/cache@v4
         with:
-          path: /home/runner/.fhir/packages
+          path: /root/.fhir/packages
           key: fhir-packages-${{ hashFiles(format('{0}/sushi-config.yaml', inputs.repo_ig)) }}
           restore-keys: |
             fhir-packages-

--- a/action.yml
+++ b/action.yml
@@ -149,11 +149,14 @@ runs:
       # On surcharge inline pour que SUSHI trouve ses packages dans /root/.fhir/packages.
       - name: Run sushi
         shell: bash
+        env:
+          CONTAINER_MODE: ${{ inputs.container_mode }}
+          REPO_IG: ${{ inputs.repo_ig }}
         run: |
-          if [ "${{ inputs.container_mode }}" = "true" ]; then
-            HOME=/root sushi ${{ inputs.repo_ig }}
+          if [ "$CONTAINER_MODE" = "true" ]; then
+            HOME=/root sushi "$REPO_IG"
           else
-            sushi ${{ inputs.repo_ig }}
+            sushi "$REPO_IG"
           fi
 
       # Résolution de la version du publisher (pour une clé de cache stable)
@@ -161,16 +164,19 @@ runs:
       - name: Resolve IG Publisher version
         id: resolve-publisher-version
         shell: bash
+        env:
+          CONTAINER_MODE: ${{ inputs.container_mode }}
+          IG_PUBLISHER_VERSION: ${{ inputs.ig-publisher-version }}
         run: |
-          if [ "${{ inputs.container_mode }}" = "true" ] && [ -f /root/publisher.jar ]; then
+          if [ "$CONTAINER_MODE" = "true" ] && [ -f /root/publisher.jar ]; then
             echo "version=image-bundled" >> $GITHUB_OUTPUT
             echo "use_bundled=true" >> $GITHUB_OUTPUT
-          elif [ "${{ inputs.ig-publisher-version }}" = "latest" ]; then
+          elif [ "$IG_PUBLISHER_VERSION" = "latest" ]; then
             VERSION=$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | jq -r '.tag_name')
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "use_bundled=false" >> $GITHUB_OUTPUT
           else
-            echo "version=${{ inputs.ig-publisher-version }}" >> $GITHUB_OUTPUT
+            echo "version=$IG_PUBLISHER_VERSION" >> $GITHUB_OUTPUT
             echo "use_bundled=false" >> $GITHUB_OUTPUT
           fi
 
@@ -187,8 +193,10 @@ runs:
       - name: 📥 Download IG Publisher
         if: steps.resolve-publisher-version.outputs.use_bundled != 'true' && steps.cache-publisher.outputs.cache-hit != 'true'
         shell: bash
+        env:
+          PUBLISHER_VERSION: ${{ steps.resolve-publisher-version.outputs.version }}
         run: |
-          wget -q https://github.com/HL7/fhir-ig-publisher/releases/download/${{ steps.resolve-publisher-version.outputs.version }}/publisher.jar
+          wget -q "https://github.com/HL7/fhir-ig-publisher/releases/download/${PUBLISHER_VERSION}/publisher.jar"
 
       # Récupération du nom de la branche afin de publier dans gh-pages
       - name: Get branch names
@@ -217,14 +225,18 @@ runs:
       # Si publisher bundlé dans l'image (/root/publisher.jar), on l'utilise directement.
       - name: 🏃‍♂️ Run IG Publisher
         shell: bash
+        env:
+          CONTAINER_MODE: ${{ inputs.container_mode }}
+          USE_BUNDLED: ${{ steps.resolve-publisher-version.outputs.use_bundled }}
+          REPO_IG: ${{ inputs.repo_ig }}
         run: |
-          if [ "${{ inputs.container_mode }}" = "true" ]; then export HOME=/root; fi
-          if [ "${{ steps.resolve-publisher-version.outputs.use_bundled }}" = "true" ]; then
+          if [ "$CONTAINER_MODE" = "true" ]; then export HOME=/root; fi
+          if [ "$USE_BUNDLED" = "true" ]; then
             PUBLISHER_JAR=/root/publisher.jar
           else
             PUBLISHER_JAR=../publisher.jar
           fi
-          cd ${{ inputs.repo_ig }}
+          cd "$REPO_IG"
           java -Xmx8192m -jar $PUBLISHER_JAR -ig . -authorise-non-conformant-tx-servers
           [ -f ./output/qa.min.html ] && cat ./output/qa.min.html >> $GITHUB_STEP_SUMMARY
           mkdir ../to_publish/ig
@@ -242,10 +254,12 @@ runs:
       - name: 🏃‍♂️ Run testscript-generator
         shell: bash
         if: ${{ inputs.generate_testscript == 'true' }}
+        env:
+          REPO_IG: ${{ inputs.repo_ig }}
         run: |
           cd testscript
           mkdir ./igs
-          cp ../${{ inputs.repo_ig }}/output/package.tgz ./igs
+          cp "../$REPO_IG/output/package.tgz" ./igs
           bundle install
           bundle exec bin/testscript_generator read mustSupport search interaction ig_directory=./igs output_path=./generated_testscripts
           mkdir ../to_publish/testscript
@@ -274,9 +288,11 @@ runs:
         if: ${{ inputs.generate_plantuml == 'true' }}
         shell: bash
         continue-on-error: true
+        env:
+          REPO_IG: ${{ inputs.repo_ig }}
         run: |
           mkdir ./plantuml
-          python ${{ github.action_path }}/PlantUML/construct.py './${{ inputs.repo_ig }}/output/package.db' './plantuml/graph.puml'
+          python ${{ github.action_path }}/PlantUML/construct.py "./$REPO_IG/output/package.db" './plantuml/graph.puml'
           [ -f plantuml.jar ] || wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O plantuml.jar
           java -jar plantuml.jar -tsvg -tpng "./plantuml"
           mkdir ./to_publish/plantuml
@@ -287,10 +303,12 @@ runs:
         if: ${{ inputs.generate_mapping_plantuml == 'true' }}
         shell: bash
         continue-on-error: true
+        env:
+          REPO_IG: ${{ inputs.repo_ig }}
         run: |
           mkdir ./plantuml_mapping
-          python ${{ github.action_path }}/PlantUML/construct_mapping_global.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
-          python ${{ github.action_path }}/PlantUML/construct_mappings.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
+          python ${{ github.action_path }}/PlantUML/construct_mapping_global.py "./$REPO_IG/output/package.db" './plantuml_mapping'
+          python ${{ github.action_path }}/PlantUML/construct_mappings.py "./$REPO_IG/output/package.db" './plantuml_mapping'
           [ -f plantuml-mapping.jar ] || wget -q https://github.com/plantuml/plantuml/releases/download/v1.2024.0/plantuml-1.2024.0.jar -O plantuml-mapping.jar
           java -jar plantuml-mapping.jar -tsvg -tpng "./plantuml_mapping"
           mkdir ./to_publish/plantuml_mapping
@@ -326,9 +344,11 @@ runs:
         if: ${{ inputs.validator_cli == 'true' }}
         shell: bash
         continue-on-error: true
+        env:
+          REPO_IG: ${{ inputs.repo_ig }}
         run: |
           mkdir ./validator_cli
-          cd ${{ inputs.repo_ig }}
+          cd "$REPO_IG"
           java -jar ../validator_cli.jar ./fsh-generated/resources -recurse -verbose -output-style compact -output ../validator_cli/rapport.html
 
       # Creation de la sortie du validator_cli dans le workflow
@@ -395,60 +415,60 @@ runs:
       - name: 🏃‍♂️ Run Publisher to release
         if: ${{ inputs.publish_repo != '' }}
         shell: bash
+        env:
+          USE_BUNDLED: ${{ steps.resolve-publisher-version.outputs.use_bundled }}
+          REPO_IG: ${{ inputs.repo_ig }}
+          PUBLISH_PATH: ${{ inputs.publish_path_outpout }}
         run: |
-          if [ "${{ steps.resolve-publisher-version.outputs.use_bundled }}" = "true" ]; then
+          if [ "$USE_BUNDLED" = "true" ]; then
             PUBLISHER_JAR=/root/publisher.jar
           else
             PUBLISHER_JAR=publisher.jar
           fi
-          java -jar $PUBLISHER_JAR -go-publish -authorise-non-conformant-tx-servers -source ${{ inputs.repo_ig }} -web ${{ inputs.publish_path_outpout }} -registry ./IG-website-release/ig-registry/fhir-ig-list.json -history ./IG-website-release/fhir-ig-history-template -templates ./IG-website-release/templates
+          java -jar $PUBLISHER_JAR -go-publish -authorise-non-conformant-tx-servers -source "$REPO_IG" -web "$PUBLISH_PATH" -registry ./IG-website-release/ig-registry/fhir-ig-list.json -history ./IG-website-release/fhir-ig-history-template -templates ./IG-website-release/templates
 
       # Commit de la release
       - name: Commit change
         if: ${{ inputs.publish_repo != '' }}
         shell: bash
+        env:
+          REPO_IG: ${{ inputs.repo_ig }}
         run: |
-          PACKAGE_ID=$(jq -r '."package-id"' ${{ inputs.repo_ig }}/publication-request.json)
-          VERSION=$(jq -r '.version' ${{ inputs.repo_ig }}/publication-request.json)
+          PACKAGE_ID=$(jq -r '."package-id"' "$REPO_IG/publication-request.json")
+          VERSION=$(jq -r '.version' "$REPO_IG/publication-request.json")
           cd IG-website-release
           git config user.name github-actions
           git config user.email github-actions@esante.gouv.fr
           git add -A
           git commit -m "Publication ${PACKAGE_ID} ${VERSION}" || echo "No changes to commit"
 
-      # Push de la release
-      - name: Push changes
-        if: ${{ inputs.publish_repo != '' }}
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ inputs.publish_repo_token }}
-          directory: IG-website-release
-          repository: ${{ inputs.publish_repo }}
-
       # Recuperation des informations du publication-request.json
       - name: Get information from PublicationRequest for GH Release
         if: ${{ inputs.publish_repo != '' }}
         shell: bash
+        env:
+          REPO_IG: ${{ inputs.repo_ig }}
         run: |
           echo 'PACKAGE_JSON<<EOF' >> $GITHUB_ENV
-          cat ${{ inputs.repo_ig }}/publication-request.json >> $GITHUB_ENV
+          cat "$REPO_IG/publication-request.json" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
       # Creation de la release en ajoutant full-ig.zip et package.tgz
       - name: Create release
         if: ${{ inputs.publish_repo != '' }}
         shell: bash
+        env:
+          PUBLISH_PATH: ${{ inputs.publish_path_outpout }}
+          GH_TOKEN: ${{ inputs.github_page_token }}
         run: |
           gh release create "${{ fromJson(env.PACKAGE_JSON).version }}" -t "Release : ${{ fromJson(env.PACKAGE_JSON).version }}" --generate-notes --repo="$GITHUB_REPOSITORY"
 
           regex='^https?:\/\/[A-Za-z0-9:.]*\/(?:.+\/)*?([^\/]+\/[^\/]+)\/?$'
           [[ ${{ fromJson(env.PACKAGE_JSON).path }} =~ $regex ]]
           file_path=${BASH_REMATCH[1]}
-          echo "${inputs.publish_path_outpout}/${file_path}/full-ig.zip"
-          gh release upload "${{ fromJson(env.PACKAGE_JSON).version }}" ${{ inputs.publish_path_outpout }}/${file_path}/full-ig.zip --repo="$GITHUB_REPOSITORY"
-          gh release upload "${{ fromJson(env.PACKAGE_JSON).version }}" ${{ inputs.publish_path_outpout }}${file_path}/package.tgz --repo="$GITHUB_REPOSITORY"
-        env:
-          GH_TOKEN: ${{ inputs.github_page_token }}
+          echo "${PUBLISH_PATH}/${file_path}/full-ig.zip"
+          gh release upload "${{ fromJson(env.PACKAGE_JSON).version }}" "${PUBLISH_PATH}/${file_path}/full-ig.zip" --repo="$GITHUB_REPOSITORY"
+          gh release upload "${{ fromJson(env.PACKAGE_JSON).version }}" "${PUBLISH_PATH}${file_path}/package.tgz" --repo="$GITHUB_REPOSITORY"
 
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -11,19 +11,19 @@ inputs:
   github_page:
     description: "Publication de l'IG sur les pages gh-pages."
     default: "false"
-    required: false    
+    required: false
   generate_plantuml:
     description: 'Génération  du diagramme plant uml dans gh-pages.'
     default: "false"
-    required: false   
+    required: false
   generate_mapping_plantuml:
     description: 'Génération des schemas plantuml de mapping dans gh-pages.'
     default: "false"
-    required: false   
+    required: false
   generate_testscript:
     description: "Génération  des fichiers testsscripts à partir de l'ig."
     default: "false"
-    required: false  
+    required: false
   repo_ig:
     description: "Chemin d'accés au repertoire de l'IG"
     required: true
@@ -46,208 +46,339 @@ inputs:
   publish_path_outpout:
     description: "Chemin de publication de l'IG."
     required: false
-    default: ""    
+    default: ""
+  use_docker_image:
+    description: "Utilise l'image pré-construite ghcr.io/ansforge/fhir-ig-builder pour éviter l'installation des outils à chaque run. Mettre à 'false' pour revenir au comportement legacy."
+    required: false
+    default: "true"
+  docker_image:
+    description: "Image Docker à utiliser quand use_docker_image est 'true'. Permet d'épingler une version spécifique."
+    required: false
+    default: "ghcr.io/ansforge/fhir-ig-builder:latest"
 runs:
   using: "composite"
   steps:
 
-
-
-
-
       #Creation du repertoire to_publish
-      - name : Create to_publish   
-        shell: bash      
-        run : mkdir to_publish
+      - name: Create to_publish
+        shell: bash
+        run: mkdir to_publish
 
-      #Install  JAVA
+      # Pull de l'image pré-construite (mode Docker)
+      - name: Pull FHIR IG Builder image
+        if: ${{ inputs.use_docker_image == 'true' }}
+        shell: bash
+        run: docker pull ${{ inputs.docker_image }}
+
+      # Install JAVA (mode legacy uniquement — le mode Docker utilise le JDK de l'image)
       - name: Setup Java JDK
+        if: ${{ inputs.use_docker_image != 'true' }}
         uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
-          java-version: '17'    
+          java-version: '17'
+
       - uses: actions/setup-node@v4
+        if: ${{ inputs.use_docker_image != 'true' }}
         with:
           node-version: 20
 
-      # Install .NET runtime la methode bake   
+      # Install .NET runtime pour la methode bake (toujours sur le runner hôte)
       - name: Setup .NET Core SDK
-        if: ${{ inputs.bake == 'true' }}       
+        if: ${{ inputs.bake == 'true' }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.x.x'
 
-      #Install  Firely pour la méthode bake   
-      - name : firely 
-        if: ${{ inputs.bake == 'true' }}   
-        shell: bash      
-        run : dotnet tool install --global Firely.Terminal --version 3.0.0  
+      # Install Firely pour la méthode bake
+      - name: firely
+        if: ${{ inputs.bake == 'true' }}
+        shell: bash
+        run: dotnet tool install --global Firely.Terminal --version 3.0.0
 
-      #Verif de la configuration pour la méthode bake
+      # Verif de la configuration pour la méthode bake
       - name: Check Firely Terminal Version
-        if: ${{ inputs.bake == 'true' }} 
-        shell: bash      
+        if: ${{ inputs.bake == 'true' }}
+        shell: bash
         run: |
-          CHECK_FIRELY_TERMINAL_VERSION=$(fhir -v | tr '\n' ' ') # Print everything in a single line
+          CHECK_FIRELY_TERMINAL_VERSION=$(fhir -v | tr '\n' ' ')
           echo "FIRELY_TERMINAL_VERSION: $CHECK_FIRELY_TERMINAL_VERSION"
 
-      #Install du frcore depuis simplifier (methode bake)      
+      # Install du frcore depuis simplifier (methode bake)
       - name: Run bake hl7.fhir.fr.core
-        if: ${{ inputs.bake == 'true' }}       
-        shell: bash            
+        if: ${{ inputs.bake == 'true' }}
+        shell: bash
         run: |
           fhir install hl7.fhir.fr.core 1.1.0
 
-      - name: Run bake  ans.annuaire.fhir.r4
-        if: ${{ inputs.bake == 'true' }}   
-        shell: bash            
+      - name: Run bake ans.annuaire.fhir.r4
+        if: ${{ inputs.bake == 'true' }}
+        shell: bash
         run: |
           fhir install ans.annuaire.fhir.r4 0.2.0
           fhir bake --package ans.annuaire.fhir.r4
 
-     #Patch sur l'installation du frcore 
+      # Patch sur l'installation du frcore
       - name: 📥 Download patch fr-core
-        if: ${{ inputs.bake == 'true' }}    
-        shell: bash            
+        if: ${{ inputs.bake == 'true' }}
+        shell: bash
         run: |
           wget -q https://raw.githubusercontent.com/ansforge/IG-workflows/main/dependency/hl7.fhir.fr.core-1.1.0.tgz -O ./hl7.fhir.fr.core-1.1.0.tgz
           cp hl7.fhir.fr.core-1.1.0.tgz ~/.fhir/packages
-          tar -xzvf ~/.fhir/packages/hl7.fhir.fr.core-1.1.0.tgz             
+          tar -xzvf ~/.fhir/packages/hl7.fhir.fr.core-1.1.0.tgz
 
-      #Install de sushi    
+      # SUSHI — mode Docker
+      - name: Run sushi
+        if: ${{ inputs.use_docker_image == 'true' }}
+        shell: bash
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace \
+            ${{ inputs.docker_image }} \
+            sushi ${{ inputs.repo_ig }}
+
+      # SUSHI — mode legacy
       - name: Install modules
-        shell: bash            
+        if: ${{ inputs.use_docker_image != 'true' }}
+        shell: bash
         run: npm install -g fsh-sushi
 
-      #Lancement de sushi 
       - name: Run sushi
-        shell: bash      
-        run: sushi  ${{ inputs.repo_ig}}
+        if: ${{ inputs.use_docker_image != 'true' }}
+        shell: bash
+        run: sushi ${{ inputs.repo_ig }}
 
-      # Téléchargement de la dernière version du publisher
-      - name: 📥 Download IG Publisher
-        shell: bash          
-        run:  |
-          if [ ${{inputs.ig-publisher-version}} = "latest" ]; then 
-            wget -q https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
-          else 
-            wget -q https://github.com/HL7/fhir-ig-publisher/releases/download/${{inputs.ig-publisher-version}}/publisher.jar
+      # Résolution de la version du publisher (pour une clé de cache stable)
+      - name: Resolve IG Publisher version
+        id: resolve-publisher-version
+        shell: bash
+        run: |
+          if [ "${{ inputs.ig-publisher-version }}" = "latest" ]; then
+            VERSION=$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | jq -r '.tag_name')
+          else
+            VERSION="${{ inputs.ig-publisher-version }}"
           fi
-        
-      #Récupération du nom de la branche afin de publier dans gh-pages
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Cache du publisher.jar par version
+      - name: Cache IG Publisher JAR
+        id: cache-publisher
+        uses: actions/cache@v4
+        with:
+          path: publisher.jar
+          key: ig-publisher-${{ steps.resolve-publisher-version.outputs.version }}
+
+      # Téléchargement du publisher uniquement en cas de cache miss
+      - name: 📥 Download IG Publisher
+        if: steps.cache-publisher.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          wget -q https://github.com/HL7/fhir-ig-publisher/releases/download/${{ steps.resolve-publisher-version.outputs.version }}/publisher.jar
+
+      # Récupération du nom de la branche afin de publier dans gh-pages
       - name: Get branch names
-        if: ${{ inputs.github_page == 'true' }}        
+        if: ${{ inputs.github_page == 'true' }}
         id: branch-name
         uses: tj-actions/branch-names@v8
 
-      #Install ruby,
+      # Ruby/Jekyll/GraphViz — mode legacy uniquement
       - uses: ruby/setup-ruby@v1
+        if: ${{ inputs.use_docker_image != 'true' }}
         with:
           ruby-version: '3.3'
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          
-      - name: Install  jekyll and graphviz
+          bundler-cache: true
+
+      - name: Install jekyll and graphviz
+        if: ${{ inputs.use_docker_image != 'true' }}
         shell: bash
         run: |
           sudo gem install jekyll
-          # PlantUML 1.2026.x (publisher 2.2.9+) est compatible avec GraphViz apt
           sudo apt-get install -y graphviz
           dot -V
 
-
-      # Creation de l'IG
+      # Run IG Publisher — mode Docker
       - name: 🏃‍♂️ Run IG Publisher
+        if: ${{ inputs.use_docker_image == 'true' }}
         shell: bash
-        run : |
-              cd  ${{ inputs.repo_ig}}
-              java -Xmx8192m -jar ../publisher.jar  -ig .   -authorise-non-conformant-tx-servers
-              [ -f ./output/qa.min.html ] && cat ./output/qa.min.html >> $GITHUB_STEP_SUMMARY
-              mkdir ../to_publish/ig
-              cp -r ./output/.  ../to_publish/ig
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace/${{ inputs.repo_ig }} \
+            ${{ inputs.docker_image }} \
+            bash -c "
+              java -Xmx8192m -jar /workspace/publisher.jar -ig . -authorise-non-conformant-tx-servers
+              [ -f ./output/qa.min.html ] && cat ./output/qa.min.html > /workspace/_qa_summary.txt || true
+              mkdir -p /workspace/to_publish/ig
+              cp -r ./output/. /workspace/to_publish/ig
+            "
+          [ -f "$GITHUB_WORKSPACE/_qa_summary.txt" ] && cat "$GITHUB_WORKSPACE/_qa_summary.txt" >> "$GITHUB_STEP_SUMMARY" || true
 
-     # Get testscript-generator
+      # Run IG Publisher — mode legacy
+      - name: 🏃‍♂️ Run IG Publisher
+        if: ${{ inputs.use_docker_image != 'true' }}
+        shell: bash
+        run: |
+          cd ${{ inputs.repo_ig }}
+          java -Xmx8192m -jar ../publisher.jar -ig . -authorise-non-conformant-tx-servers
+          [ -f ./output/qa.min.html ] && cat ./output/qa.min.html >> $GITHUB_STEP_SUMMARY
+          mkdir ../to_publish/ig
+          cp -r ./output/. ../to_publish/ig
+
+      # Get testscript-generator
       - name: Get testscript-generator
-        if: ${{ inputs.generate_testscript == 'true' }} 
+        if: ${{ inputs.generate_testscript == 'true' }}
         uses: actions/checkout@main
         with:
           persist-credentials: false
           repository: M-Priour/testscript-generator
-          path: testscript     
+          path: testscript
 
       - name: 🏃‍♂️ Run testscript-generator
-        shell: bash      
-        if: ${{ inputs.generate_testscript == 'true' }} 
-        run : |
-              cd  testscript
-              mkdir ./igs
-              cp ../${{ inputs.repo_ig}}/output/package.tgz ./igs
-              bundle install
-              bundle exec bin/testscript_generator read mustSupport search interaction  ig_directory./igs output_path=./generated_testscripts
-              mkdir ../to_publish/testscript
-              cp -r ./generated_testscripts/.  ../to_publish/testscript
+        shell: bash
+        if: ${{ inputs.generate_testscript == 'true' }}
+        run: |
+          cd testscript
+          mkdir ./igs
+          cp ../${{ inputs.repo_ig }}/output/package.tgz ./igs
+          bundle install
+          bundle exec bin/testscript_generator read mustSupport search interaction  ig_directory./igs output_path=./generated_testscripts
+          mkdir ../to_publish/testscript
+          cp -r ./generated_testscripts/. ../to_publish/testscript
 
-      #Install de python pour la génération du graph plantUml
-      - name: Setup Python # Set Python version
-        if: ${{ inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true' }}  
+      # Python — mode legacy uniquement (l'image Docker contient déjà Python)
+      - name: Setup Python
+        if: ${{ (inputs.generate_plantuml == 'true' || inputs.generate_mapping_plantuml == 'true') && inputs.use_docker_image != 'true' }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10' 
+          python-version: '3.10'
 
-      #Creation du graphique plantUML et publication dans gh-pages
+      # PlantUML — mode Docker
       - name: Run script plantuml
-        if: ${{ inputs.generate_plantuml == 'true' }}        
-        shell: bash   
+        if: ${{ inputs.generate_plantuml == 'true' && inputs.use_docker_image == 'true' }}
+        shell: bash
         continue-on-error: true
-        run : |
-              mkdir ./plantuml
-              python ${{ github.action_path }}/PlantUML/construct.py './${{ inputs.repo_ig}}/output/package.db' './plantuml/graph.puml'
-              wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar
-              java -jar plantuml-1.2026.6.jar  -tsvg -tpng  "./plantuml"
-              mkdir ./to_publish/plantuml
-              cp -r ./plantuml/.  ./to_publish/plantuml
+        run: |
+          mkdir ./plantuml
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -v "${{ github.action_path }}:/opt/ig-workflows" \
+            -w /workspace \
+            ${{ inputs.docker_image }} \
+            bash -c "
+              python3 /opt/ig-workflows/PlantUML/construct.py './${{ inputs.repo_ig }}/output/package.db' './plantuml/graph.puml'
+              wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar -O /tmp/plantuml.jar
+              java -jar /tmp/plantuml.jar -tsvg -tpng ./plantuml
+            "
+          mkdir ./to_publish/plantuml
+          cp -r ./plantuml/. ./to_publish/plantuml
 
-      #Creation du graphique plantUML et publication dans gh-pages
+      # PlantUML — mode legacy
+      - name: Run script plantuml
+        if: ${{ inputs.generate_plantuml == 'true' && inputs.use_docker_image != 'true' }}
+        shell: bash
+        continue-on-error: true
+        run: |
+          mkdir ./plantuml
+          python ${{ github.action_path }}/PlantUML/construct.py './${{ inputs.repo_ig }}/output/package.db' './plantuml/graph.puml'
+          wget -q https://github.com/plantuml/plantuml/releases/download/v1.2026.6/plantuml-1.2026.6.jar
+          java -jar plantuml-1.2026.6.jar -tsvg -tpng "./plantuml"
+          mkdir ./to_publish/plantuml
+          cp -r ./plantuml/. ./to_publish/plantuml
+
+      # PlantUML mapping — mode Docker
       - name: Run scripts mapping plantuml
-        if: ${{ inputs.generate_mapping_plantuml == 'true' }}        
-        shell: bash   
+        if: ${{ inputs.generate_mapping_plantuml == 'true' && inputs.use_docker_image == 'true' }}
+        shell: bash
         continue-on-error: true
-        run : |
-              mkdir ./plantuml_mapping
-              python ${{ github.action_path }}/PlantUML/construct_mapping_global.py './${{ inputs.repo_ig}}/output/package.db' './plantuml_mapping'
-              python ${{ github.action_path }}/PlantUML/construct_mappings.py './${{ inputs.repo_ig}}/output/package.db' './plantuml_mapping'
-              wget -q https://github.com/plantuml/plantuml/releases/download/v1.2024.0/plantuml-1.2024.0.jar
-              java -jar plantuml-1.2024.0.jar  -tsvg -tpng  "./plantuml"
-              mkdir ./to_publish/plantuml_mapping
-              cp -r ./plantuml_mapping/.  ./to_publish/plantuml_mapping
+        run: |
+          mkdir ./plantuml_mapping
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -v "${{ github.action_path }}:/opt/ig-workflows" \
+            -w /workspace \
+            ${{ inputs.docker_image }} \
+            bash -c "
+              python3 /opt/ig-workflows/PlantUML/construct_mapping_global.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
+              python3 /opt/ig-workflows/PlantUML/construct_mappings.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
+              wget -q https://github.com/plantuml/plantuml/releases/download/v1.2024.0/plantuml-1.2024.0.jar -O /tmp/plantuml-mapping.jar
+              java -jar /tmp/plantuml-mapping.jar -tsvg -tpng ./plantuml_mapping
+            "
+          mkdir ./to_publish/plantuml_mapping
+          cp -r ./plantuml_mapping/. ./to_publish/plantuml_mapping
 
-      #Téléchargement de la dernière version du validator_cli
+      # PlantUML mapping — mode legacy
+      - name: Run scripts mapping plantuml
+        if: ${{ inputs.generate_mapping_plantuml == 'true' && inputs.use_docker_image != 'true' }}
+        shell: bash
+        continue-on-error: true
+        run: |
+          mkdir ./plantuml_mapping
+          python ${{ github.action_path }}/PlantUML/construct_mapping_global.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
+          python ${{ github.action_path }}/PlantUML/construct_mappings.py './${{ inputs.repo_ig }}/output/package.db' './plantuml_mapping'
+          wget -q https://github.com/plantuml/plantuml/releases/download/v1.2024.0/plantuml-1.2024.0.jar
+          java -jar plantuml-1.2024.0.jar -tsvg -tpng "./plantuml"
+          mkdir ./to_publish/plantuml_mapping
+          cp -r ./plantuml_mapping/. ./to_publish/plantuml_mapping
+
+      # Résolution de la version du validator_cli
+      - name: Resolve validator_cli version
+        if: ${{ inputs.validator_cli == 'true' }}
+        id: resolve-validator-version
+        shell: bash
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/hapifhir/org.hl7.fhir.core/releases/latest | jq -r '.tag_name')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Cache du validator_cli.jar
+      - name: Cache validator_cli JAR
+        if: ${{ inputs.validator_cli == 'true' }}
+        id: cache-validator-cli
+        uses: actions/cache@v4
+        with:
+          path: validator_cli.jar
+          key: validator-cli-${{ steps.resolve-validator-version.outputs.version }}
+
+      # Téléchargement du validator_cli uniquement en cas de cache miss
       - name: 📥 Download test tools
-        if: ${{ inputs.validator_cli == 'true' }}   
-        shell: bash            
+        if: ${{ inputs.validator_cli == 'true' && steps.cache-validator-cli.outputs.cache-hit != 'true' }}
+        shell: bash
         run: |
           wget -q https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar
 
-
-      #Lancement des tests avec le validator_cli    
+      # Run validator_cli — mode Docker
       - name: ✔️ Run tests
-        if: ${{ inputs.validator_cli == 'true' }}  
-        shell: bash       
-        run: |
-              mkdir ./validator_cli
-              cd  ${{ inputs.repo_ig}}
-              java -jar ../validator_cli.jar ./fsh-generated/resources -recurse -verbose -output-style compact -output ../validator_cli/rapport.html
+        if: ${{ inputs.validator_cli == 'true' && inputs.use_docker_image == 'true' }}
+        shell: bash
         continue-on-error: true
+        run: |
+          mkdir ./validator_cli
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace/${{ inputs.repo_ig }} \
+            ${{ inputs.docker_image }} \
+            java -jar /workspace/validator_cli.jar ./fsh-generated/resources -recurse -verbose -output-style compact -output /workspace/validator_cli/rapport.html
 
-      #Creation de la sortie du validator_cli dans le workflow
+      # Run validator_cli — mode legacy
+      - name: ✔️ Run tests
+        if: ${{ inputs.validator_cli == 'true' && inputs.use_docker_image != 'true' }}
+        shell: bash
+        continue-on-error: true
+        run: |
+          mkdir ./validator_cli
+          cd ${{ inputs.repo_ig }}
+          java -jar ../validator_cli.jar ./fsh-generated/resources -recurse -verbose -output-style compact -output ../validator_cli/rapport.html
+
+      # Creation de la sortie du validator_cli dans le workflow
       - name: Generate list using Markdown
-        if: ${{ inputs.validator_cli == 'true' }}     
-        shell: bash       
+        if: ${{ inputs.validator_cli == 'true' }}
+        shell: bash
         run: |
           mkdir ./to_publish/validator_cli
-          cp -r ./validator_cli/.  ./to_publish/validator_cli
+          cp -r ./validator_cli/. ./to_publish/validator_cli
           echo "### Rapport de validation (validator_cli)  :rocket:" >> $GITHUB_STEP_SUMMARY
           cat ./validator_cli/rapport.html >> $GITHUB_STEP_SUMMARY
-       
+
       - name: Create .gitignore for gh-pages
         if: ${{ inputs.github_page == 'true' }}
         shell: bash
@@ -266,96 +397,100 @@ runs:
 
 #####Release###########
 
+      # Java nécessaire sur le runner hôte pour le mode Docker + release
+      - name: Setup Java JDK (for release)
+        if: ${{ inputs.use_docker_image == 'true' && inputs.publish_repo != '' }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'microsoft'
+          java-version: '17'
 
-      #Suppression cache ubuntu
+      # Suppression cache ubuntu
       - name: Free Disk Space (Ubuntu)
-        if: ${{ inputs.publish_repo != '' }}          
+        if: ${{ inputs.publish_repo != '' }}
         uses: insightsengineering/disk-space-reclaimer@v1
         with:
           tools-cache: false
           android: true
 
-      #Affichage des partitions
-      - name: size    
-        if: ${{ inputs.publish_repo != '' }}   
-        shell: bash     
+      # Affichage des partitions
+      - name: size
+        if: ${{ inputs.publish_repo != '' }}
+        shell: bash
         run: |
           df -h
 
-      #Récupération du repo de publication
+      # Récupération du repo de publication
       - name: Get publish_repo
-        if: ${{ inputs.publish_repo != '' }}       
+        if: ${{ inputs.publish_repo != '' }}
         uses: actions/checkout@main
         with:
           persist-credentials: false
-          repository:  ${{ inputs.publish_repo}}
+          repository: ${{ inputs.publish_repo }}
           path: IG-website-release
 
-      #Initialisation du repo
-      - name: Init   publish_repo  
-        if: ${{ inputs.publish_repo != '' }}             
+      # Initialisation du repo
+      - name: Init publish_repo
+        if: ${{ inputs.publish_repo != '' }}
         shell: bash
         run: |
-          cd  IG-website-release
+          cd IG-website-release
           git submodule update --init --recursive
 
-      #Lancement de la release dans le repo
-      - name: 🏃‍♂️ Run  Publisher to release
-        if: ${{ inputs.publish_repo != '' }}  
-        shell: bash                
-        run :   java -jar publisher.jar -go-publish    -authorise-non-conformant-tx-servers  -source  ${{ inputs.repo_ig}}  -web  ${{  inputs.publish_path_outpout }} -registry ./IG-website-release/ig-registry/fhir-ig-list.json -history ./IG-website-release/fhir-ig-history-template -templates ./IG-website-release/templates 
-                
+      # Lancement de la release dans le repo
+      - name: 🏃‍♂️ Run Publisher to release
+        if: ${{ inputs.publish_repo != '' }}
+        shell: bash
+        run: java -jar publisher.jar -go-publish -authorise-non-conformant-tx-servers -source ${{ inputs.repo_ig }} -web ${{ inputs.publish_path_outpout }} -registry ./IG-website-release/ig-registry/fhir-ig-list.json -history ./IG-website-release/fhir-ig-history-template -templates ./IG-website-release/templates
 
-      #Commit de la release
+      # Commit de la release
       - name: Commit change
-        if: ${{ inputs.publish_repo != '' }}  
-        shell: bash              
+        if: ${{ inputs.publish_repo != '' }}
+        shell: bash
         run: |
-          PACKAGE_ID=$(jq -r '."package-id"' ${{ inputs.repo_ig}}/publication-request.json)
-          VERSION=$(jq -r '.version' ${{ inputs.repo_ig}}/publication-request.json)
-          cd  IG-website-release
+          PACKAGE_ID=$(jq -r '."package-id"' ${{ inputs.repo_ig }}/publication-request.json)
+          VERSION=$(jq -r '.version' ${{ inputs.repo_ig }}/publication-request.json)
+          cd IG-website-release
           git config user.name github-actions
           git config user.email github-actions@esante.gouv.fr
-          git add -A 
+          git add -A
           git commit -m "Publication ${PACKAGE_ID} ${VERSION}" || echo "No changes to commit"
-          
-      #Push de la release
-      - name: Push changes 
-        if: ${{ inputs.publish_repo != '' }}          
+
+      # Push de la release
+      - name: Push changes
+        if: ${{ inputs.publish_repo != '' }}
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ inputs.publish_repo_token}}
+          github_token: ${{ inputs.publish_repo_token }}
           directory: IG-website-release
-          repository : ${{ inputs.publish_repo}}
+          repository: ${{ inputs.publish_repo }}
 
-      # recuperation des informations du publication-request.json
+      # Recuperation des informations du publication-request.json
       - name: Get information from PublicationRequest for GH Release
-        if: ${{ inputs.publish_repo != '' }}  
-        shell: bash       
+        if: ${{ inputs.publish_repo != '' }}
+        shell: bash
         run: |
           echo 'PACKAGE_JSON<<EOF' >> $GITHUB_ENV
-          cat ${{ inputs.repo_ig}}/publication-request.json >> $GITHUB_ENV
+          cat ${{ inputs.repo_ig }}/publication-request.json >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
-      #Creation de la release en ajoutant full-ig.zip et package.tgz
+      # Creation de la release en ajoutant full-ig.zip et package.tgz
       - name: Create release
-        if: ${{ inputs.publish_repo != '' }}  
-        shell: bash       
+        if: ${{ inputs.publish_repo != '' }}
+        shell: bash
         run: |
-          gh release create "${{ fromJson(env.PACKAGE_JSON).version }}" -t "Release : ${{  fromJson(env.PACKAGE_JSON).version }}"  --generate-notes  --repo="$GITHUB_REPOSITORY" 
-          
+          gh release create "${{ fromJson(env.PACKAGE_JSON).version }}" -t "Release : ${{ fromJson(env.PACKAGE_JSON).version }}" --generate-notes --repo="$GITHUB_REPOSITORY"
+
           regex='^https?:\/\/[A-Za-z0-9:.]*\/(?:.+\/)*?([^\/]+\/[^\/]+)\/?$'
           [[ ${{ fromJson(env.PACKAGE_JSON).path }} =~ $regex ]]
           file_path=${BASH_REMATCH[1]}
-          echo  "${inputs.publish_path_outpout}/${file_path}/full-ig.zip"
-          gh release upload "${{ fromJson(env.PACKAGE_JSON).version }}" ${{  inputs.publish_path_outpout }}/${file_path }/full-ig.zip  --repo="$GITHUB_REPOSITORY" 
-          gh release upload "${{ fromJson(env.PACKAGE_JSON).version }}" ${{  inputs.publish_path_outpout }}${file_path }/package.tgz --repo="$GITHUB_REPOSITORY" 
+          echo "${inputs.publish_path_outpout}/${file_path}/full-ig.zip"
+          gh release upload "${{ fromJson(env.PACKAGE_JSON).version }}" ${{ inputs.publish_path_outpout }}/${file_path}/full-ig.zip --repo="$GITHUB_REPOSITORY"
+          gh release upload "${{ fromJson(env.PACKAGE_JSON).version }}" ${{ inputs.publish_path_outpout }}${file_path}/package.tgz --repo="$GITHUB_REPOSITORY"
         env:
-          GH_TOKEN:  ${{ inputs.github_page_token }}
-        
+          GH_TOKEN: ${{ inputs.github_page_token }}
+
 
 branding:
   icon: 'check'
   color: 'blue'
-
-          

--- a/fhir-packages.txt
+++ b/fhir-packages.txt
@@ -7,3 +7,4 @@ hl7.fhir.fr.core 2.2.0
 ans.fhir.fr.annuaire 1.1.0
 ans.fr.terminologies latest
 hl7.fhir.uv.extensions.r4 latest
+hl7.fhir.xver-extensions latest

--- a/fhir-packages.txt
+++ b/fhir-packages.txt
@@ -6,3 +6,4 @@ hl7.fhir.fr.core 2.1.0
 hl7.fhir.fr.core 2.2.0
 ans.fhir.fr.annuaire 1.1.0
 ans.fr.terminologies latest
+hl7.fhir.uv.extensions.r4 latest

--- a/fhir-packages.txt
+++ b/fhir-packages.txt
@@ -8,3 +8,5 @@ ans.fhir.fr.annuaire 1.1.0
 ans.fr.terminologies latest
 hl7.fhir.uv.extensions.r4 latest
 hl7.fhir.xver-extensions latest
+ans.fr.nos 1.3.0
+ans.fr.nos 1.5.0

--- a/fhir-packages.txt
+++ b/fhir-packages.txt
@@ -10,3 +10,4 @@ hl7.fhir.uv.extensions.r4 latest
 hl7.fhir.xver-extensions latest
 ans.fr.nos 1.3.0
 ans.fr.nos 1.5.0
+hl7.fhir.pubpack latest

--- a/scripts/install-fhir-packages.mjs
+++ b/scripts/install-fhir-packages.mjs
@@ -1,0 +1,13 @@
+import fpi from 'fhir-package-installer';
+import { readFileSync } from 'fs';
+
+const lines = readFileSync(process.argv[2] || 'fhir-packages.txt', 'utf8').split('\n');
+
+for (const line of lines) {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) continue;
+  const [id, version = 'latest'] = trimmed.split(/\s+/);
+  const packageId = version === 'latest' ? id : `${id}@${version}`;
+  console.log(`Installing ${packageId}...`);
+  await fpi.install(packageId);
+}


### PR DESCRIPTION
## Description des changements

* Nouveau mode `use_docker_image` (défaut `true`) : SUSHI, IG Publisher, PlantUML et validator_cli s'exécutent dans l'image pré-construite `ghcr.io/ansforge/fhir-ig-builder` via `docker run`, éliminant 3 à 8 minutes d'installation d'outils à chaque run
* `Dockerfile` et workflow `build-docker.yml` ajoutés directement dans ce repo — le `GITHUB_TOKEN` scoped à `ansforge` peut pousser vers `ghcr.io/ansforge/fhir-ig-builder` sans PAT supplémentaire
* Cache `actions/cache@v4` pour `publisher.jar` et `validator_cli.jar` (clé = version résolue) : économise 30 à 90 s supplémentaires par run
* Nouvel input `docker_image` pour épingler une version d'image spécifique
* Compatibilité descendante totale : `use_docker_image: false` restaure le comportement legacy exact

## Type de changement

- [x] Nouveau contenu — optimisation performance (réduction GitHub Minutes)

## Checklist

- [x] Compatibilité descendante : les workflows existants n'ont rien à modifier
- [x] Escape hatch disponible : `use_docker_image: false`
- [x] Image Docker buildée depuis ce repo (GITHUB_TOKEN ansforge → ghcr.io/ansforge)
- [ ] Valider sur un run réel d'un IG ANS avant merge

## Image Docker

- **Registre** : `ghcr.io/ansforge/fhir-ig-builder`
- **Build** : automatique sur push touchant `Dockerfile`, cron hebdo (lundi 06:00 UTC), ou `workflow_dispatch`
- **Contenu** : Java 17, Node 20, SUSHI 3.20.0, Ruby, Jekyll, GraphViz, Python 3, gh CLI

## Preview

https://ansforge.github.io/IG-workflows/docker-image-optimization/ig