### PR TITLE
fix: restaurer le step Push changes supprimé accidentellement

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -473,6 +473,15 @@ runs:
           git add -A
           git commit -m "Publication ${PACKAGE_ID} ${VERSION}" || echo "No changes to commit"
 
+      # Push de la release
+      - name: Push changes
+        if: ${{ inputs.publish_repo != '' }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ inputs.publish_repo_token }}
+          directory: IG-website-release
+          repository: ${{ inputs.publish_repo }}
+
       # Recuperation des informations du publication-request.json
       - name: Get information from PublicationRequest for GH Release
         if: ${{ inputs.publish_repo != '' }}


### PR DESCRIPTION
## Description des changements

* Restauration du step `Push changes` (ad-m/github-push-action@master) supprimé accidentellement dans dc4716c
* Sans ce step, le `git commit` de la release restait local — rien n'était jamais poussé dans `publish_repo`

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [x] Correction (erreur dans un profil, une page, une dépendance)
- [ ] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [ ] La branche est à jour avec `main`

## Contexte

Le step a été supprimé lors du refactoring `feat: Docker image optimization + container_mode + sécurité` (dc4716c). Il ne figure pas dans le message de commit de ce PR — suppression accidentelle.