### PR TITLE
fix: délimiteur aléatoire pour éviter 'Matching delimiter not found EOF'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -480,9 +480,13 @@ runs:
         env:
           REPO_IG: ${{ inputs.repo_ig }}
         run: |
-          echo 'PACKAGE_JSON<<EOF' >> $GITHUB_ENV
-          cat "$REPO_IG/publication-request.json" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          DELIMITER=$(openssl rand -hex 16)
+          JSON_CONTENT=$(cat "$REPO_IG/publication-request.json")
+          {
+            echo "PACKAGE_JSON<<${DELIMITER}"
+            echo "$JSON_CONTENT"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
 
       # Creation de la release en ajoutant full-ig.zip et package.tgz
       - name: Create release


### PR DESCRIPTION
## Description des changements

* Remplacement du délimiteur fixe `EOF` par un délimiteur aléatoire (`openssl rand -hex 16`) dans le step "Get information from PublicationRequest for GH Release"
* Capture du JSON dans une variable avant d'écrire dans `$GITHUB_ENV` : si `cat` échoue, bash sort sur l'erreur _avant_ d'ouvrir le heredoc, évitant ainsi le heredoc non fermé

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [x] Correction (erreur dans un profil, une page, une dépendance)
- [ ] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Contexte

Avec `bash -e -o pipefail`, si `cat "$REPO_IG/publication-request.json"` échoue, le script quitte immédiatement sans écrire la ligne de fermeture `EOF` dans `$GITHUB_ENV`. GHA tente ensuite de parser le fichier d'env et lève :

```
Error: Unable to process file command 'env' successfully.
Error: Invalid value. Matching delimiter not found 'EOF'
```

Observé sur : https://github.com/ansforge/IG-fhir-medicosocial-suivi-decisions-orientation/actions/runs/28357880894/job/84005120229

## Checklist

- [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`