### PR TITLE
debug: inspecter ~/.fhir/packages juste avant le Publisher

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -179,6 +179,24 @@ runs:
         shell: bash
         run: npm install -g fsh-sushi
 
+      # [DEBUG TEMPORAIRE] Inspection de ~/.fhir/packages AVANT le premier lancement de SUSHI,
+      # pour comparer avec l'état juste avant le Publisher et voir si SUSHI (re)génère un
+      # .index.json qui serait ensuite mal réutilisé par le SUSHI interne au Publisher.
+      # À retirer une fois la cause confirmée.
+      - name: 🔍 [DEBUG TEMPORAIRE] Inspecter ~/.fhir/packages AVANT le 1er Run SUSHI
+        shell: bash
+        env:
+          CONTAINER_MODE: ${{ inputs.container_mode }}
+        run: |
+          if [ "$CONTAINER_MODE" = "true" ]; then export HOME=/root; fi
+          echo "HOME=$HOME"
+          echo "--- hl7.fhir.fr.core#1.1.0/package : présence de .index.json ? ---"
+          ls -la "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/.index.json" 2>&1 || echo ".index.json absent (avant sushi)"
+          echo "--- fichiers contenant 'organization' dans ce package ---"
+          ls "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/" 2>&1 | grep -i organi || echo "(aucun / dossier absent)"
+          echo "--- ans.annuaire.fhir.r4#0.2.0/package : présence de .index.json ? ---"
+          ls -la "$HOME/.fhir/packages/ans.annuaire.fhir.r4#0.2.0/package/.index.json" 2>&1 || echo ".index.json absent (avant sushi)"
+
       # Compilation des sources FSH en ressources FHIR via SUSHI.
       # En container_mode, GHA force HOME=/github/home → on override pour que SUSHI trouve /root/.fhir/packages.
       - name: 🔨 Run SUSHI
@@ -276,8 +294,16 @@ runs:
           echo "--- fr.core / annuaire présents ? ---"
           ls -la "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0" 2>&1 || echo "hl7.fhir.fr.core#1.1.0 absent"
           ls -la "$HOME/.fhir/packages/ans.annuaire.fhir.r4#0.2.0" 2>&1 || echo "ans.annuaire.fhir.r4#0.2.0 absent"
-          echo "--- snapshot présent dans FrOrganization ? ---"
-          grep -l '"snapshot"' "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/StructureDefinition-FrOrganization.json" 2>&1 || echo "pas de snapshot ou fichier absent"
+          echo "--- .index.json (fr.core) présent APRÈS le 1er run sushi ? ---"
+          ls -la "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/.index.json" 2>&1 || echo ".index.json absent (après sushi)"
+          echo "--- .index.json (annuaire) présent APRÈS le 1er run sushi ? ---"
+          ls -la "$HOME/.fhir/packages/ans.annuaire.fhir.r4#0.2.0/package/.index.json" 2>&1 || echo ".index.json absent (après sushi)"
+          echo "--- fr-organization référencé dans .index.json (fr.core) ? ---"
+          grep -i "organization" "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/.index.json" 2>&1 || echo "pas trouvé / fichier absent"
+          echo "--- fichier réel de fr-organization dans le package (nommage non standard connu) ---"
+          ls "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/" 2>&1 | grep -i organi || echo "(aucun / dossier absent)"
+          echo "--- snapshot présent dans le fichier réel fr-organization-R4.StructureDefinition.json ? ---"
+          grep -l '"snapshot"' "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/fr-organization-R4.StructureDefinition.json" 2>&1 || echo "pas de snapshot ou fichier absent"
 
       # Exécution du publisher FHIR — étape la plus longue du build (plusieurs minutes).
       # En container_mode, HOME=/root est forcé pour que le subprocess SUSHI spawné par le Publisher

--- a/action.yml
+++ b/action.yml
@@ -258,6 +258,27 @@ runs:
           sudo apt-get install -y graphviz
           dot -V
 
+      # [DEBUG TEMPORAIRE] Inspection de l'état de ~/.fhir/packages juste avant le Publisher,
+      # pour diagnostiquer pourquoi le SUSHI relancé en interne par le Publisher (FSHRunner)
+      # semble re-télécharger tous les packages au lieu de réutiliser ceux déjà baked.
+      # À retirer une fois la cause confirmée.
+      - name: 🔍 [DEBUG TEMPORAIRE] Inspecter l'état de ~/.fhir/packages avant le Publisher
+        shell: bash
+        env:
+          CONTAINER_MODE: ${{ inputs.container_mode }}
+        run: |
+          if [ "$CONTAINER_MODE" = "true" ]; then export HOME=/root; fi
+          echo "HOME=$HOME"
+          echo "whoami=$(whoami)"
+          echo "PWD=$PWD"
+          echo "--- contenu de \$HOME/.fhir/packages ---"
+          ls -la "$HOME/.fhir/packages" 2>&1 || echo "(absent)"
+          echo "--- fr.core / annuaire présents ? ---"
+          ls -la "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0" 2>&1 || echo "hl7.fhir.fr.core#1.1.0 absent"
+          ls -la "$HOME/.fhir/packages/ans.annuaire.fhir.r4#0.2.0" 2>&1 || echo "ans.annuaire.fhir.r4#0.2.0 absent"
+          echo "--- snapshot présent dans FrOrganization ? ---"
+          grep -l '"snapshot"' "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/StructureDefinition-FrOrganization.json" 2>&1 || echo "pas de snapshot ou fichier absent"
+
       # Exécution du publisher FHIR — étape la plus longue du build (plusieurs minutes).
       # En container_mode, HOME=/root est forcé pour que le subprocess SUSHI spawné par le Publisher
       # utilise /root/.fhir/packages et non /github/home/.fhir/packages.

--- a/action.yml
+++ b/action.yml
@@ -305,6 +305,26 @@ runs:
           echo "--- snapshot présent dans le fichier réel fr-organization-R4.StructureDefinition.json ? ---"
           grep -l '"snapshot"' "$HOME/.fhir/packages/hl7.fhir.fr.core#1.1.0/package/fr-organization-R4.StructureDefinition.json" 2>&1 || echo "pas de snapshot ou fichier absent"
 
+      # [DEBUG TEMPORAIRE] Reproduction en bash de l'appel exact que fait le Publisher en interne
+      # (FSHRunner: cwd = dossier IG, commande "sushi . -o .") pour savoir si le re-téléchargement
+      # de tous les packages est lié aux arguments/cwd, ou uniquement au lancement via la JVM.
+      # À retirer une fois la cause confirmée.
+      - name: 🔍 [DEBUG TEMPORAIRE] Reproduire l'appel sushi du Publisher (cwd + args identiques)
+        shell: bash
+        env:
+          CONTAINER_MODE: ${{ inputs.container_mode }}
+          REPO_IG: ${{ inputs.repo_ig }}
+        run: |
+          if [ "$CONTAINER_MODE" = "true" ]; then export HOME=/root; fi
+          echo "HOME=$HOME"
+          cd "$REPO_IG"
+          echo "PWD=$PWD"
+          sushi . -o . 2>&1 | tee /tmp/sushi-repro.log || true
+          echo "--- occurrences de 'Attempting to download' dans cette 3e exécution ---"
+          grep -c "Attempting to download" /tmp/sushi-repro.log || echo "0"
+          echo "--- erreurs 'missing a snapshot' dans cette 3e exécution ---"
+          grep "missing a snapshot" /tmp/sushi-repro.log || echo "(aucune)"
+
       # Exécution du publisher FHIR — étape la plus longue du build (plusieurs minutes).
       # En container_mode, HOME=/root est forcé pour que le subprocess SUSHI spawné par le Publisher
       # utilise /root/.fhir/packages et non /github/home/.fhir/packages.


### PR DESCRIPTION
Step temporaire pour diagnostiquer pourquoi le SUSHI relancé en interne par l'IG Publisher (FSHRunner) semble re-télécharger tous les packages FHIR au lieu de réutiliser ceux déjà baked par le step précédent, causant des erreurs "missing a snapshot" côté ROR.