### PR TITLE
fix: retirer le cache Docker qui figeait la version de l'IG Publisher

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -39,8 +39,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/ansforge/fhir-ig-builder:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Verify image
         run: |
@@ -49,3 +47,5 @@ jobs:
           docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest jekyll --version
           docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest dot -V
           docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest python3 --version
+          echo "IG Publisher version baked into image:"
+          docker run --rm ghcr.io/ansforge/fhir-ig-builder:latest cat /root/publisher-version.txt

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,6 +3,10 @@ name: Build and Push FHIR IG Builder image
 on:
   push:
     branches: [main]
+    paths:
+      - Dockerfile
+      - fhir-packages.txt
+      - .github/workflows/build-docker.yml
   workflow_dispatch:
   schedule:
     # Rebuild hebdomadaire lundi 06:00 UTC pour capter les nouvelles versions SUSHI

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,10 +3,6 @@ name: Build and Push FHIR IG Builder image
 on:
   push:
     branches: [main]
-    paths:
-      - Dockerfile
-      - fhir-packages.txt
-      - .github/workflows/build-docker.yml
   workflow_dispatch:
   schedule:
     # Rebuild hebdomadaire lundi 06:00 UTC pour capter les nouvelles versions SUSHI

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN java -version && node --version && sushi --version && jekyll --version && do
 RUN PUBLISHER_VERSION=$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | jq -r '.tag_name') \
     && wget -q "https://github.com/HL7/fhir-ig-publisher/releases/download/${PUBLISHER_VERSION}/publisher.jar" \
         -O /root/publisher.jar \
+    && echo "${PUBLISHER_VERSION}" > /root/publisher-version.txt \
     && echo "IG Publisher ${PUBLISHER_VERSION} pre-installed at /root/publisher.jar"
 
 # Warmup : télécharge les packages FHIR listés dans fhir-packages.txt dans /root/.fhir/packages/


### PR DESCRIPTION
## Description des changements

* Suppression de `cache-from`/`cache-to: type=gha` dans `build-docker.yml` : ce cache de layers BuildKit gardait le layer `RUN PUBLISHER_VERSION=...` en `CACHED` à chaque rebuild (le texte de l'instruction ne changeant jamais), donc `publisher.jar` restait figé sur une ancienne version malgré le rebuild hebdomadaire (cron) — le publisher 2.3.0 n'était toujours pas pris en compte 3 jours après sa sortie. Le build ne tournant qu'une fois par semaine, le gain de temps du cache ne justifiait pas ce risque.
* Ajout d'un fichier marqueur `/root/publisher-version.txt` (écrit dans le `Dockerfile`) et de son affichage dans l'étape `Verify image`, pour que la version du publisher réellement embarquée soit visible dans le log de chaque build.

## Type de changement

- [x] Correction (erreur dans un profil, une page, une dépendance)

## Contexte

Repro : voir le run https://github.com/ansforge/IG-workflows/actions/runs/30811514697 — le step "Build and push" du jour montre `#11 CACHED` sur le layer de téléchargement du publisher, malgré un rebuild manuel déclenché le jour même.