### PR TITLE
fix: ajouter pages/menu au warmup pour éviter l'échec Jekyll (menu.xml)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ WORKDIR /opt/warmup
 COPY fhir-packages.txt .
 COPY scripts/generate-warmup-config.mjs .
 COPY scripts/synthetic-ig/ig.ini ./synthetic-ig/
+COPY scripts/synthetic-ig/input/pagecontent ./synthetic-ig/input/pagecontent
 RUN mkdir -p synthetic-ig/input/fsh \
     && node generate-warmup-config.mjs fhir-packages.txt synthetic-ig/sushi-config.yaml
 RUN cd synthetic-ig \

--- a/scripts/generate-warmup-config.mjs
+++ b/scripts/generate-warmup-config.mjs
@@ -23,6 +23,11 @@ copyrightYear: 2026+
 releaseLabel: ci-build
 dependencies:
 ${deps}
+pages:
+    index.md:
+        title: Warmup
+menu:
+    Home: index.html
 `;
 writeFileSync(outputFile, yaml);
 console.log(`Warmup sushi-config généré avec ${Object.keys(pkgs).length} dépendances : ${Object.keys(pkgs).join(', ')}`);

--- a/scripts/synthetic-ig/input/pagecontent/index.md
+++ b/scripts/synthetic-ig/input/pagecontent/index.md
@@ -1,0 +1,3 @@
+### Warmup
+
+Page technique générée pour le warmup du cache de packages FHIR.


### PR DESCRIPTION
## Description des changements

* L'IG FHIR synthétique utilisée pour le warmup Docker (téléchargement/indexation des packages FHIR listés dans `fhir-packages.txt`) n'avait ni page ni menu défini dans son `sushi-config.yaml`. Sans ça, le Publisher ne peut pas générer `_includes/menu.xml`, et l'étape finale de rendu Jekyll échouait avec `Liquid Exception: Could not locate the included file 'menu.xml'`. L'échec était masqué par `|| true` (le build Docker ne casse pas), mais polluait les logs.
* Ajout d'une page minimale `scripts/synthetic-ig/input/pagecontent/index.md` et des sections `pages:`/`menu:` générées dans `scripts/generate-warmup-config.mjs`, sur le modèle des autres IGs ansforge (ex. `IG-fhir-annuaire`), qui génèrent `_includes/menu.xml` automatiquement à partir de cette config sans fichier `input/includes/menu.xml` manuel.
* `Dockerfile` copie maintenant `scripts/synthetic-ig/input/pagecontent` dans l'IG synthétique lors du build de l'image.

Vérifié en local (sushi + `publisher.jar -ig . -tx n/a`) : `Jekyll: done in 0.278 seconds.`, plus d'erreur `menu.xml`, build complet du warmup terminé sans échec.

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [x] Correction (erreur dans un profil, une page, une dépendance)
- [ ] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Test plan

- [x] `node scripts/generate-warmup-config.mjs fhir-packages.txt /tmp/sushi-config.yaml` génère bien `pages:`/`menu:`
- [x] `sushi .` sur l'IG synthétique modifiée : 0 Errors, 0 Warnings
- [x] `java -jar publisher.jar -ig . -tx n/a` en local : Jekyll se termine sans erreur (`Jekyll: done in 0.278 seconds.`)
- [ ] Confirmer sur le workflow `build-docker.yml` (build de l'image sur cette PR) que l'erreur `menu.xml` a disparu des logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)