### PR TITLE
feat: enrichir la description OCI de l'image Docker (versions + packages + date)

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,6 +32,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve versions
+        id: versions
+        run: |
+          PUBLISHER_VERSION=$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | jq -r '.tag_name')
+          SUSHI_VERSION=$(curl -s https://registry.npmjs.org/fsh-sushi/latest | jq -r '.version')
+          node scripts/generate-warmup-config.mjs fhir-packages.txt /tmp/warmup-sushi-config.yaml
+          PACKAGES_LIST=$(awk '/^dependencies:/{flag=1;next}/^[^ ]/{flag=0}flag' /tmp/warmup-sushi-config.yaml \
+            | sed 's/^ *//;s/: /@/' | paste -sd ',' -)
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "publisher=${PUBLISHER_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sushi=${SUSHI_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "packages=${PACKAGES_LIST}" >> "$GITHUB_OUTPUT"
+          echo "date=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -39,6 +53,14 @@ jobs:
           push: true
           tags: |
             ghcr.io/ansforge/fhir-ig-builder:latest
+          build-args: |
+            PUBLISHER_VERSION=${{ steps.versions.outputs.publisher }}
+            SUSHI_VERSION=${{ steps.versions.outputs.sushi }}
+            PACKAGES_LIST=${{ steps.versions.outputs.packages }}
+            BUILD_DATE=${{ steps.versions.outputs.date }}
+          labels: |
+            org.opencontainers.image.description=Image Docker pour la publication de guides d'implémentation FHIR ANS (SUSHI + IG Publisher + Jekyll). IG Publisher ${{ steps.versions.outputs.publisher }}, SUSHI ${{ steps.versions.outputs.sushi }}. Packages FHIR préchargés : ${{ steps.versions.outputs.packages }}.
+            org.opencontainers.image.created=${{ steps.versions.outputs.date }}
 
       - name: Verify image
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:24.04
 
 ARG NODE_MAJOR=20
+ARG SUSHI_VERSION=latest
+ARG PUBLISHER_VERSION
+ARG PACKAGES_LIST
+ARG BUILD_DATE
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
@@ -31,8 +35,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# SUSHI (dernière version stable)
-RUN npm install -g fsh-sushi
+# SUSHI
+RUN npm install -g fsh-sushi@${SUSHI_VERSION}
 
 # Jekyll
 RUN gem install jekyll --no-document
@@ -48,12 +52,15 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 RUN java -version && node --version && sushi --version && jekyll --version && dot -V && python3 --version
 
-# Pré-télécharger le IG Publisher JAR (version latest au moment du build de l'image)
-RUN PUBLISHER_VERSION=$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | jq -r '.tag_name') \
+# Pré-télécharger le IG Publisher JAR (version résolue par le workflow, ou latest en fallback pour un build local)
+RUN PUBLISHER_VERSION="${PUBLISHER_VERSION:-$(curl -s https://api.github.com/repos/HL7/fhir-ig-publisher/releases/latest | jq -r '.tag_name')}" \
     && wget -q "https://github.com/HL7/fhir-ig-publisher/releases/download/${PUBLISHER_VERSION}/publisher.jar" \
         -O /root/publisher.jar \
     && echo "${PUBLISHER_VERSION}" > /root/publisher-version.txt \
     && echo "IG Publisher ${PUBLISHER_VERSION} pre-installed at /root/publisher.jar"
+
+LABEL org.opencontainers.image.description="Image Docker pour la publication de guides d'implémentation FHIR ANS (SUSHI + IG Publisher + Jekyll). IG Publisher ${PUBLISHER_VERSION}, SUSHI ${SUSHI_VERSION}. Packages FHIR préchargés : ${PACKAGES_LIST}." \
+      org.opencontainers.image.created="${BUILD_DATE}"
 
 # Warmup : télécharge les packages FHIR listés dans fhir-packages.txt dans /root/.fhir/packages/
 # et génère les index de packages (.index.db) pour chacun via le publisher.


### PR DESCRIPTION
## Description des changements

* Ajout du label `org.opencontainers.image.description` sur l'image `ghcr.io/ansforge/fhir-ig-builder`, contenant : une ligne descriptive, la version de l'IG Publisher embarquée, la version de SUSHI embarquée, et la liste des packages FHIR préchargés (`fhir-packages.txt`, dédupliqués comme le fait déjà `scripts/generate-warmup-config.mjs`).
* Ajout du label standard `org.opencontainers.image.created` avec la date de publication (UTC, RFC 3339).
* Ces valeurs sont résolues une fois dans une nouvelle étape "Resolve versions" du workflow `build-docker.yml`, puis passées à la fois en `build-args` (pour que le `Dockerfile` installe précisément les versions annoncées : SUSHI n'était auparavant pas pinnée) et en `labels` du step `docker/build-push-action`.
* Le `Dockerfile` pose aussi son propre `LABEL` (avec fallback sur la résolution "latest" existante côté Publisher si l'ARG n'est pas fourni), pour rester correct sur un build local — dans ce cas rare, certains champs du label peuvent être vides ou par défaut, sans impact sur l'image réellement publiée sur `ghcr.io` qui passe toujours par le workflow.

Résultat visible sur la page GHCR du package : description avec versions + packages préchargés + date de publication, au lieu d'aucune information aujourd'hui.

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [ ] Correction (erreur dans un profil, une page, une dépendance)
- [x] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Test plan

- [x] `node scripts/generate-warmup-config.mjs fhir-packages.txt /tmp/test.yaml` puis extraction awk/sed testée en local → produit bien `hl7.fhir.fr.core@2.2.0,ans.fhir.fr.annuaire@1.1.0,...`
- [x] Résolution des versions Publisher/SUSHI/date testée en local (appels API réels)
- [x] Syntaxe YAML du workflow validée
- [ ] Vérifier après merge que le job `build-and-push` s'exécute correctement et que la description du package `ghcr.io/ansforge/fhir-ig-builder` est bien mise à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)