### PR TITLE
fix: exposer la description/date de l'image via des annotations OCI

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -79,6 +79,9 @@ jobs:
           labels: |
             org.opencontainers.image.description=Image Docker pour la publication de guides d'implémentation FHIR ANS (SUSHI + IG Publisher + Jekyll). IG Publisher ${{ steps.versions.outputs.publisher }}, SUSHI ${{ steps.versions.outputs.sushi }}. Packages FHIR préchargés : ${{ steps.versions.outputs.packages }}.
             org.opencontainers.image.created=${{ steps.versions.outputs.date }}
+          annotations: |
+            index,manifest:org.opencontainers.image.description=Image Docker pour la publication de guides d'implémentation FHIR ANS (SUSHI + IG Publisher + Jekyll). IG Publisher ${{ steps.versions.outputs.publisher }}, SUSHI ${{ steps.versions.outputs.sushi }}. Packages FHIR préchargés : ${{ steps.versions.outputs.packages }}.
+            index,manifest:org.opencontainers.image.created=${{ steps.versions.outputs.date }}
 
       - name: Verify image
         run: |

--- a/DOCKER_IMAGE.md
+++ b/DOCKER_IMAGE.md
@@ -33,18 +33,24 @@ Le workflow `build-docker.yml` se lance :
 - manuellement (`workflow_dispatch`),
 - automatiquement chaque **lundi à 06:00 UTC** (cron), pour capter les nouvelles versions de SUSHI/IG Publisher sans changement de fichier.
 
-## Labels OCI (métadonnées visibles sur la page du package)
+## Labels et annotations OCI (métadonnées visibles sur la page du package)
 
-Le workflow résout, avant chaque build (étape *Resolve versions*), et expose comme labels OCI de l'image :
+Le workflow résout, avant chaque build (étape *Resolve versions*), puis expose les mêmes informations sous deux formes :
 - `org.opencontainers.image.description` : ligne descriptive + version de l'IG Publisher embarquée + version de SUSHI embarquée + liste des packages FHIR préchargés (`id@version`, séparés par des virgules)
 - `org.opencontainers.image.created` : date de publication (UTC, RFC 3339)
 
-Ces valeurs sont aussi passées en `build-args` au `Dockerfile` (`PUBLISHER_VERSION`, `SUSHI_VERSION`, `PACKAGES_LIST`, `BUILD_DATE`), afin que la version de SUSHI réellement installée corresponde exactement à celle annoncée dans le label (SUSHI n'est plus installé en `latest` implicite au niveau du `Dockerfile`, mais pinné à la version résolue par le workflow).
+Ces valeurs sont aussi passées en `build-args` au `Dockerfile` (`PUBLISHER_VERSION`, `SUSHI_VERSION`, `PACKAGES_LIST`, `BUILD_DATE`), afin que la version de SUSHI réellement installée corresponde exactement à celle annoncée (SUSHI n'est plus installé en `latest` implicite au niveau du `Dockerfile`, mais pinné à la version résolue par le workflow).
 
-Pour inspecter les labels d'une image déjà publiée :
+**Labels vs annotations** : le `Dockerfile` pose ces clés en `LABEL` (donc dans la config de l'image, `Config.Labels`), et le step *Build and push* les pose en plus en tant qu'**annotations OCI** (`annotations: index,manifest:org.opencontainers.image.description=...`) via `docker/build-push-action`. C'est nécessaire car l'image publiée est un *manifest index* (buildx produit un index même pour une seule plateforme) — GHCR affiche la description du package à partir des **annotations de l'index/manifest**, pas des `Config.Labels` de l'image. Sans les annotations, la page du package affiche "No description provided" même si le `LABEL` Dockerfile est bien présent.
+
+Pour inspecter labels et annotations d'une image déjà publiée :
 ```bash
+# Labels (Config.Labels de l'image, posés par le Dockerfile)
 docker inspect ghcr.io/ansforge/fhir-ig-builder:latest \
   --format '{{ index .Config.Labels "org.opencontainers.image.description" }}'
+
+# Annotations (index/manifest OCI, celles lues par la page GHCR)
+docker buildx imagetools inspect ghcr.io/ansforge/fhir-ig-builder:latest --format '{{ json .Manifest.Annotations }}'
 ```
 
 ## Tags et politique de rétention


### PR DESCRIPTION
## Description des changements

* Ajoute `annotations: index,manifest:org.opencontainers.image.description=...` et `index,manifest:org.opencontainers.image.created=...` au step "Build and push" (`docker/build-push-action`).
* Met à jour `DOCKER_IMAGE.md` pour expliquer la différence entre labels (`Config.Labels`, posés par le `Dockerfile`) et annotations OCI (index/manifest, lues par la page du package GHCR).

## Pourquoi

Après le merge de #46/#47, la page du package `ghcr.io/ansforge/fhir-ig-builder` affichait toujours "No description provided" malgré le `LABEL org.opencontainers.image.description` du `Dockerfile`. Cause : l'image publiée est un *manifest index* OCI (buildx en produit un même pour une seule plateforme), et GHCR lit la description depuis les **annotations de l'index/manifest**, pas depuis les `Config.Labels` de l'image — le message d'erreur affiché par GHCR le confirme explicitement pour ce cas ("For multi-arch images, set a value... in the annotations field of the manifest").

## Type de changement

- [x] Correction (erreur dans un profil, une page, une dépendance)

## Test plan

- [ ] Après merge : vérifier sur https://github.com/ansforge/IG-workflows/pkgs/container/fhir-ig-builder que la description s'affiche bien sur la prochaine version publiée
- [x] `docker buildx imagetools inspect` documenté dans `DOCKER_IMAGE.md` pour vérifier les annotations directement

🤖 Generated with [Claude Code](https://claude.com/claude-code)