### PR TITLE
fix: build cassé — n'annoter que le manifest OCI, pas l'index

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -80,8 +80,8 @@ jobs:
             org.opencontainers.image.description=Image Docker pour la publication de guides d'implémentation FHIR ANS (SUSHI + IG Publisher + Jekyll). IG Publisher ${{ steps.versions.outputs.publisher }}, SUSHI ${{ steps.versions.outputs.sushi }}. Packages FHIR préchargés : ${{ steps.versions.outputs.packages }}.
             org.opencontainers.image.created=${{ steps.versions.outputs.date }}
           annotations: |
-            index,manifest:org.opencontainers.image.description=Image Docker pour la publication de guides d'implémentation FHIR ANS (SUSHI + IG Publisher + Jekyll). IG Publisher ${{ steps.versions.outputs.publisher }}, SUSHI ${{ steps.versions.outputs.sushi }}. Packages FHIR préchargés : ${{ steps.versions.outputs.packages }}.
-            index,manifest:org.opencontainers.image.created=${{ steps.versions.outputs.date }}
+            manifest:org.opencontainers.image.description=Image Docker pour la publication de guides d'implémentation FHIR ANS (SUSHI + IG Publisher + Jekyll). IG Publisher ${{ steps.versions.outputs.publisher }}, SUSHI ${{ steps.versions.outputs.sushi }}. Packages FHIR préchargés : ${{ steps.versions.outputs.packages }}.
+            manifest:org.opencontainers.image.created=${{ steps.versions.outputs.date }}
 
       - name: Verify image
         run: |

--- a/DOCKER_IMAGE.md
+++ b/DOCKER_IMAGE.md
@@ -41,7 +41,9 @@ Le workflow résout, avant chaque build (étape *Resolve versions*), puis expose
 
 Ces valeurs sont aussi passées en `build-args` au `Dockerfile` (`PUBLISHER_VERSION`, `SUSHI_VERSION`, `PACKAGES_LIST`, `BUILD_DATE`), afin que la version de SUSHI réellement installée corresponde exactement à celle annoncée (SUSHI n'est plus installé en `latest` implicite au niveau du `Dockerfile`, mais pinné à la version résolue par le workflow).
 
-**Labels vs annotations** : le `Dockerfile` pose ces clés en `LABEL` (donc dans la config de l'image, `Config.Labels`), et le step *Build and push* les pose en plus en tant qu'**annotations OCI** (`annotations: index,manifest:org.opencontainers.image.description=...`) via `docker/build-push-action`. C'est nécessaire car l'image publiée est un *manifest index* (buildx produit un index même pour une seule plateforme) — GHCR affiche la description du package à partir des **annotations de l'index/manifest**, pas des `Config.Labels` de l'image. Sans les annotations, la page du package affiche "No description provided" même si le `LABEL` Dockerfile est bien présent.
+**Labels vs annotations** : le `Dockerfile` pose ces clés en `LABEL` (donc dans la config de l'image, `Config.Labels`), et le step *Build and push* les pose en plus en tant qu'**annotations OCI de niveau manifest** (`annotations: manifest:org.opencontainers.image.description=...`) via `docker/build-push-action`. GHCR affiche la description du package à partir des annotations du manifest, pas des `Config.Labels` — sans elles, la page du package affiche "No description provided" même si le `LABEL` Dockerfile est bien présent.
+
+Attention : `provenance: false` (voir plus bas) fait que l'image est publiée en export **mono-plateforme sans index OCI**. Le préfixe `index:` sur une annotation échoue alors le build (`index annotations not supported for single platform export`) — seul le préfixe `manifest:` est valide ici. Si `provenance`/le multi-arch étaient réactivés un jour, il faudrait repasser à `index,manifest:` pour couvrir les deux niveaux.
 
 Pour inspecter labels et annotations d'une image déjà publiée :
 ```bash


### PR DESCRIPTION
## Description des changements

* `annotations:` du step "Build and push" : retire le préfixe `index,` et ne garde que `manifest:` pour `org.opencontainers.image.description` et `org.opencontainers.image.created`.
* Met à jour `DOCKER_IMAGE.md` en conséquence, avec une note expliquant pourquoi `index:` n'est pas utilisable ici.

## Pourquoi

Le run déclenché par le merge de #48 a échoué : https://github.com/ansforge/IG-workflows/actions/runs/30820461275/job/91708796586

```
ERROR: failed to build: failed to solve: index annotations not supported for single platform export
```

Avec `provenance: false` (introduit en #47), `docker/build-push-action` publie un export **mono-plateforme sans index OCI** — le préfixe `index:` sur une annotation est donc invalide dans ce contexte et fait planter tout le build. Seul `manifest:` s'applique à un export mono-plateforme.

## Type de changement

- [x] Correction (erreur dans un profil, une page, une dépendance)

## Test plan

- [ ] Après merge : vérifier que le prochain run de `build-docker.yml` (push ou `workflow_dispatch`) passe bien l'étape "Build and push"
- [ ] Vérifier sur https://github.com/ansforge/IG-workflows/pkgs/container/fhir-ig-builder que la description s'affiche

🤖 Generated with [Claude Code](https://claude.com/claude-code)